### PR TITLE
PyQt6 imshow + viewer fixes + annotated-image callback

### DIFF
--- a/aim_fsm/__init__.py
+++ b/aim_fsm/__init__.py
@@ -23,4 +23,14 @@ from viewer.worldmap_viewer import WorldMapViewer
 from viewer.particle_viewer import ParticleViewer
 from viewer.path_viewer import PathViewer
 
+# PyQt6 imshow() API - cv2-compatible functions
+from viewer import (
+    namedWindow,
+    imshow,
+    waitKey,
+    destroyWindow,
+    destroyAllWindows,
+)
+
+
 del base

--- a/aim_fsm/aruco.py
+++ b/aim_fsm/aruco.py
@@ -53,6 +53,7 @@ class RobotArucoDetector(object):
         self.disabled_ids = disabled_ids  # disable markers with high false detection rates
         self.ids = []
         self.corners = []
+        self._last_image_shape = None
         self.marker_size = marker_size #these units will be pose est units!!
         self.object_corners = np.array([
             [-marker_size / 2, marker_size / 2, 0],  # Top left
@@ -64,6 +65,7 @@ class RobotArucoDetector(object):
     def process_image(self,gray):
         self.seen_marker_ids = []
         self.seen_marker_objects = dict()
+        self._last_image_shape = gray.shape[:2]
         (self.corners, self.ids, _) = self.detector.detectMarkers(gray)
         if self.ids is None: return
 
@@ -89,9 +91,45 @@ class RobotArucoDetector(object):
             self.seen_marker_ids.append(id)
             self.seen_marker_objects[id] = marker
 
-    def annotate(self, image, scale_factor):
-        scaled_corners = [ np.multiply(corner, scale_factor) for corner in self.corners ]
-        displayim = cv2.aruco.drawDetectedMarkers(image, scaled_corners, self.ids)
+    def _scale_corners(self, scale_x, scale_y):
+        if scale_x == 1.0 and scale_y == 1.0:
+            return self.corners
+        scaled = []
+        for corner in self.corners:
+            scaled_corner = corner.copy()
+            scaled_corner[..., 0] = scaled_corner[..., 0] * scale_x
+            scaled_corner[..., 1] = scaled_corner[..., 1] * scale_y
+            scaled.append(scaled_corner)
+        return scaled
+
+    def annotate(self, image, scale_factor=1):
+        if image is None or self.ids is None or not self.corners:
+            return image
+        if not hasattr(cv2, "aruco"):
+            return image
+
+        height, width = image.shape[:2]
+        scale_x = 1.0
+        scale_y = 1.0
+        if self._last_image_shape is not None:
+            src_h, src_w = self._last_image_shape
+            if src_h and src_w and (src_h != height or src_w != width):
+                scale_x = width / src_w
+                scale_y = height / src_h
+        elif scale_factor not in (None, 1, 1.0):
+            scale_x = float(scale_factor)
+            scale_y = float(scale_factor)
+
+        scaled_corners = self._scale_corners(scale_x, scale_y)
+
+        base = image.copy()
+        overlay = np.zeros_like(base)
+        overlay_bgr = cv2.cvtColor(overlay, cv2.COLOR_RGB2BGR)
+        cv2.aruco.drawDetectedMarkers(overlay_bgr, scaled_corners, self.ids)
+        overlay_rgb = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGB)
+        mask = np.any(overlay_rgb != 0, axis=2)
+        base[mask] = overlay_rgb[mask]
+        displayim = base
 
         #add poses currently fails since image is already scaled. How to scale camMat?
         #if(self.ids is not None):

--- a/aim_fsm/program.py
+++ b/aim_fsm/program.py
@@ -1,4 +1,6 @@
 from math import pi
+import time
+from typing import Any, Callable, Optional
 import re
 from importlib import __import__, reload
 try:
@@ -23,6 +25,8 @@ from .utils import Pose
 from viewer.particle_viewer import ParticleViewer
 from .rrt import RRT
 from viewer.path_viewer import PathViewer
+from viewer.camera_overlay import apply_overlays
+from .camera import AIVISION_RESOLUTION_SCALE
 #from . import custom_objs
 #from .perched import *
 #from .sharedmap import *
@@ -36,6 +40,7 @@ class StateMachineProgram(StateNode):
                  force_annotation = False,   # set to True for annotation even without cam_viewer
                  annotate_sdk = True,        # include annotations for SDK's object detections
                  annotated_scale_factor = 1, # set to 1 to avoid cost of resizing images
+                 annotated_image_callback: Optional[Callable[[Any, dict], None]] = None,
                  viewer_crosshairs = False,  # set to True to draw viewer crosshairs
                  speech = True,
 
@@ -74,6 +79,7 @@ class StateMachineProgram(StateNode):
         self.annotate_sdk = annotate_sdk
         self.force_annotation = force_annotation
         self.annotated_scale_factor = annotated_scale_factor
+        self.annotated_image_callback = annotated_image_callback
         self.viewer_crosshairs = viewer_crosshairs
         self.speech = speech
         self.num_particles = num_particles
@@ -210,6 +216,45 @@ class StateMachineProgram(StateNode):
     def user_annotate(self,image):
         return image
 
+    def _annotated_metadata(self, status: Optional[dict]) -> dict:
+        meta = {
+            "timestamp": time.time(),
+            "frame_count": getattr(self.robot, "frame_count", None),
+            "status": status,
+            "pose": getattr(self.robot, "pose", None),
+            "camera_resolution": getattr(getattr(self.robot, "camera", None), "resolution", None),
+            "annotate_sdk": bool(self.annotate_sdk),
+            "scale": int(AIVISION_RESOLUTION_SCALE) or 1,
+        }
+        try:
+            meta["aivision"] = (status or {}).get("aivision")
+        except Exception:
+            meta["aivision"] = None
+        return meta
+
+    def _emit_annotated_frame(self, image):
+        callback = getattr(self, "annotated_image_callback", None)
+        if callback is None:
+            return
+        status = getattr(self.robot, "status", None)
+        overlay_status = status if self.annotate_sdk else None
+        annotated = apply_overlays(
+            image,
+            overlay_status,
+            int(AIVISION_RESOLUTION_SCALE) or 1,
+            getattr(self.robot, "aruco_detector", None),
+            self.user_annotate,
+        )
+        try:
+            self.robot.annotated_image = annotated.copy()
+        except Exception:
+            pass
+        meta = self._annotated_metadata(status)
+        try:
+            callback(annotated, meta)
+        except Exception:
+            pass
+
     def process_image(self,image):
         # Aruco image processing
         gray = cv2.cvtColor(image,cv2.COLOR_BGR2GRAY)
@@ -217,7 +262,9 @@ class StateMachineProgram(StateNode):
             self.robot.aruco_detector.process_image(gray)
         # Other image processors can run here if the user supplies them.
         self.user_image(image,gray)
-        if self.force_annotation and not self.robot.cam_viewer:
+        if self.annotated_image_callback is not None:
+            self._emit_annotated_frame(image)
+        elif self.force_annotation and not self.robot.cam_viewer:
             self.user_annotate(image)
 
 ################
@@ -280,4 +327,3 @@ def runfsm(module_name, running_modules=dict()):
     running_fsm = the_class()
     evbase.robot_for_loading.loop.call_soon_threadsafe(running_fsm.start)
     return running_fsm
-

--- a/qml/PathViewer.qml
+++ b/qml/PathViewer.qml
@@ -47,6 +47,8 @@ FocusScope {
             implicitWidth: 280
             source: viewerApp ? viewerApp.wavefrontSource : ""
             squareSizeMm: viewerApp ? viewerApp.wavefrontSquareSize : 5.0
+            originX: viewerApp ? viewerApp.wavefrontOriginX : 0.0
+            originY: viewerApp ? viewerApp.wavefrontOriginY : 0.0
             viewState: root.viewStateRef
         }
     }

--- a/qml/SimpleImshow.qml
+++ b/qml/SimpleImshow.qml
@@ -1,0 +1,16 @@
+import QtQuick 6.5
+
+Item {
+    id: root
+    objectName: "simpleImshow"
+    width: 640
+    height: 480
+
+    Image {
+        id: imageDisplay
+        anchors.fill: parent
+        fillMode: Image.PreserveAspectFit
+        cache: false  // CRITICAL: prevent QML from caching the image
+        source: "image://imshow/frame?v=" + frameId
+    }
+}

--- a/qml/layers/WavefrontView.qml
+++ b/qml/layers/WavefrontView.qml
@@ -7,6 +7,8 @@ Item {
     property string source: ""
     property real squareSizeMm: 5.0
     property var viewState: null
+    property real originX: 0.0
+    property real originY: 0.0
     property color backgroundColor: "#0f161f"
     property color borderColor: "#203041"
 
@@ -18,45 +20,74 @@ Item {
         color: backgroundColor
         border.color: borderColor
         border.width: 1
+    }
+
+    Item {
+        id: viewport
+        anchors.fill: parent
+        anchors.margins: 8
+        clip: true
 
         Image {
             id: wavefrontImage
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.verticalCenter: parent.verticalCenter
             source: root.source
-            fillMode: Image.PreserveAspectFit
             smooth: false
             visible: root.source.length > 0
-            width: contentWidth()
-            height: contentHeight()
-
-            function contentWidth() {
-                if (!visible)
-                    return 0;
-                var pxPerMm = root.viewState && root.viewState.zoom !== undefined ? root.viewState.zoom : 0.64;
-                var cellMm = Math.max(1.0, root.squareSizeMm);
-                var imageWidth = sourceSize.width > 0 ? sourceSize.width : implicitWidth;
-                var widthPx = imageWidth * cellMm * pxPerMm;
-                return Math.min(parent.width - 16, widthPx);
-            }
-
-            function contentHeight() {
-                if (!visible)
-                    return 0;
-                var pxPerMm = root.viewState && root.viewState.zoom !== undefined ? root.viewState.zoom : 0.64;
-                var cellMm = Math.max(1.0, root.squareSizeMm);
-                var imageHeight = sourceSize.height > 0 ? sourceSize.height : implicitHeight;
-                var heightPx = imageHeight * cellMm * pxPerMm;
-                return Math.min(parent.height - 16, heightPx);
-            }
+            fillMode: Image.Stretch
+            width: root.imageWidth()
+            height: root.imageHeight()
+            x: root.imageX()
+            y: root.imageY()
         }
+    }
 
-        Label {
-            anchors.centerIn: parent
-            visible: root.source.length === 0
-            text: qsTr("Wavefront\nunavailable")
-            horizontalAlignment: Text.AlignHCenter
-            color: "#54657a"
-        }
+    Label {
+        anchors.centerIn: parent
+        visible: root.source.length === 0
+        text: qsTr("Wavefront\nunavailable")
+        horizontalAlignment: Text.AlignHCenter
+        color: "#54657a"
+    }
+
+    function pixelsPerMm() {
+        if (!root.viewState || root.viewState.zoom === undefined || root.viewState.zoom === null)
+            return 0.64;
+        return Math.max(0.01, root.viewState.zoom);
+    }
+
+    function centerX() {
+        if (!root.viewState || root.viewState.centerX === undefined)
+            return 0;
+        return root.viewState.centerX;
+    }
+
+    function centerY() {
+        if (!root.viewState || root.viewState.centerY === undefined)
+            return 0;
+        return root.viewState.centerY;
+    }
+
+    function imageScale() {
+        return pixelsPerMm() * Math.max(1.0, root.squareSizeMm);
+    }
+
+    function imageWidth() {
+        if (!wavefrontImage.visible || wavefrontImage.sourceSize.width <= 0)
+            return 0;
+        return wavefrontImage.sourceSize.width * imageScale();
+    }
+
+    function imageHeight() {
+        if (!wavefrontImage.visible || wavefrontImage.sourceSize.height <= 0)
+            return 0;
+        return wavefrontImage.sourceSize.height * imageScale();
+    }
+
+    function imageX() {
+        return (root.originX - centerX()) * pixelsPerMm() + viewport.width / 2;
+    }
+
+    function imageY() {
+        return (centerY() - root.originY) * pixelsPerMm() + viewport.height / 2;
     }
 }

--- a/simple_cli
+++ b/simple_cli
@@ -16,6 +16,7 @@ import logging
 import os
 import platform
 import re
+import signal
 import readline
 import rlcompleter
 import subprocess
@@ -42,10 +43,18 @@ import aim_fsm
 from aim_fsm import *
 from aim_fsm.program import runfsm as _program_runfsm
 
+try:
+    from viewer.imshow_manager import imshow_pump
+except Exception:
+    imshow_pump = None
+
 ################ Configuration
 
 # tab completion
 readline.parse_and_bind('tab: complete')
+
+# Qt event processing flag (set by SIGALRM handler)
+_qt_needs_processing = False
 
 # history file
 if 'HOME' in os.environ:  # Linux
@@ -67,6 +76,21 @@ os_version = platform.system()
 # Put current directory on search path.
 if '.' not in sys.path:
     sys.path.append('.')
+
+
+def _qt_event_handler(signum, frame):
+    """Signal handler - only set flag, never call Qt here."""
+    global _qt_needs_processing
+    _qt_needs_processing = True
+
+
+if hasattr(signal, "SIGALRM") and hasattr(signal, "setitimer"):
+    try:
+        signal.signal(signal.SIGALRM, _qt_event_handler)
+        signal.setitimer(signal.ITIMER_REAL, 0.05, 0.05)
+    except ValueError:
+        # Signals only work in the main thread; ignore if not available.
+        pass
 
 ################ CLI functions
 
@@ -165,6 +189,8 @@ def _drain_pending_viewer_launches_once():
             break
         _prime_default_viewers(program, launch_flags)
         processed = True
+    if imshow_pump is not None:
+        imshow_pump()
     return processed
 
 
@@ -182,6 +208,19 @@ def _process_pending_viewer_launches(timeout=0.0):
         if remaining <= 0.0:
             break
         time.sleep(min(0.01, remaining))
+
+def _process_qt_events_if_needed():
+    global _qt_needs_processing
+    if not _qt_needs_processing:
+        return
+    _qt_needs_processing = False
+    try:
+        from PyQt6.QtGui import QGuiApplication
+    except ImportError:
+        return
+    app = QGuiApplication.instance()
+    if app:
+        app.processEvents()
 
 def cli_loop(_robot):
     global ans, RUNNING, robot, file_to_run, running_fsm
@@ -210,6 +249,7 @@ def cli_loop(_robot):
         cli_loop._line = ''
         while cli_loop._line == '':
             running_fsm = aim_fsm.program.running_fsm
+            _process_qt_events_if_needed()
             _process_pending_viewer_launches()
             readline.write_history_file(histfile)
             try:

--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -19,6 +19,15 @@ __all__ = [
     "SnapshotService",
     "WorldMapModel",
     "WorldMapViewer",
+    # PyQt6 imshow() API
+    "namedWindow",
+    "imshow",
+    "waitKey",
+    "destroyWindow",
+    "destroyAllWindows",
+    "ImshowImageProvider",
+    "ImshowWindow",
+    "WindowManager",
 ]
 
 
@@ -36,6 +45,15 @@ _MODULE_MAP = {
     "SnapshotService": ("viewer.snapshot_service", "SnapshotService"),
     "WorldMapModel": ("viewer.worldmap_model", "WorldMapModel"),
     "WorldMapViewer": ("viewer.worldmap_viewer", "WorldMapViewer"),
+    # PyQt6 imshow() API
+    "namedWindow": ("viewer.imshow_manager", "namedWindow"),
+    "imshow": ("viewer.imshow_manager", "imshow"),
+    "waitKey": ("viewer.imshow_manager", "waitKey"),
+    "destroyWindow": ("viewer.imshow_manager", "destroyWindow"),
+    "destroyAllWindows": ("viewer.imshow_manager", "destroyAllWindows"),
+    "ImshowImageProvider": ("viewer.imshow_provider", "ImshowImageProvider"),
+    "ImshowWindow": ("viewer.imshow_window", "ImshowWindow"),
+    "WindowManager": ("viewer.imshow_manager", "WindowManager"),
 }
 
 

--- a/viewer/imshow_manager.py
+++ b/viewer/imshow_manager.py
@@ -1,0 +1,271 @@
+"""Global window manager and cv2-compatible API for PyQt6 imshow()."""
+
+from __future__ import annotations
+
+import threading
+import time
+from queue import Empty, SimpleQueue
+from typing import Dict, Optional
+
+import numpy as np
+from PyQt6.QtCore import QCoreApplication, QEventLoop, QThread
+
+from .imshow_window import ImshowWindow
+
+
+class WindowManager:
+    """Global registry for imshow windows.
+
+    Manages multiple named windows, mimicking cv2's global window management.
+    Thread-safe singleton pattern using module-level instance.
+    """
+
+    def __init__(self) -> None:
+        self._windows: Dict[str, ImshowWindow] = {}
+        self._lock = threading.Lock()
+        self._pending_ops: SimpleQueue[tuple[str, str | None]] = SimpleQueue()
+        self._pending_images: Dict[str, np.ndarray] = {}
+        self._pending_lock = threading.Lock()
+        self._processing = False
+
+    @staticmethod
+    def _on_main_thread() -> bool:
+        return threading.current_thread() is threading.main_thread()
+
+    def create_window(self, window_name: str) -> ImshowWindow:
+        """Create or retrieve window by name.
+
+        Args:
+            window_name: Name of the window
+
+        Returns:
+            ImshowWindow instance (creates new if doesn't exist)
+
+        Raises:
+            ValueError: If window_name is empty
+        """
+        if not isinstance(window_name, str) or not window_name:
+            raise ValueError("window_name must be a non-empty string")
+
+        with self._lock:
+            if window_name not in self._windows:
+                self._windows[window_name] = ImshowWindow(window_name)
+            return self._windows[window_name]
+
+    def get_window(self, window_name: str) -> Optional[ImshowWindow]:
+        """Get existing window or None.
+
+        Args:
+            window_name: Name of the window
+
+        Returns:
+            ImshowWindow instance or None if not found
+        """
+        with self._lock:
+            return self._windows.get(window_name)
+
+    def destroy_window(self, window_name: str) -> None:
+        """Close and remove window.
+
+        Args:
+            window_name: Name of the window to destroy
+        """
+        if not self._on_main_thread():
+            self._pending_ops.put(("destroyWindow", window_name))
+            return
+        self._destroy_window_main_thread(window_name)
+
+    def destroy_all_windows(self) -> None:
+        """Close and remove all windows."""
+        if not self._on_main_thread():
+            self._pending_ops.put(("destroyAllWindows", None))
+            return
+        self._destroy_all_windows_main_thread()
+
+    def imshow(self, window_name: str, image: np.ndarray) -> None:
+        """Display image in named window (creates if needed).
+
+        Args:
+            window_name: Name of the window
+            image: HxW grayscale, HxWx3 BGR, or HxWx4 BGRA numpy array (uint8)
+        """
+        if not self._on_main_thread():
+            window = self.get_window(window_name)
+            if window is not None:
+                window.display(image)
+                return
+            with self._pending_lock:
+                self._pending_images[window_name] = image
+            self._pending_ops.put(("namedWindow", window_name))
+            return
+        self._imshow_main_thread(window_name, image)
+        self._process_events()
+
+    def wait_key(self, delay_ms: int = 0) -> int:
+        """Process Qt events briefly.
+
+        Args:
+            delay_ms: Delay in milliseconds (0 = single event pass)
+
+        Returns:
+            -1 (key support not implemented)
+        """
+        if self._on_main_thread():
+            self.process_pending()
+        self._process_events(delay_ms)
+        return -1  # No key support
+
+    def process_pending(self, process_events: bool = True) -> None:
+        if not self._on_main_thread():
+            return
+        if self._processing:
+            return
+        self._processing = True
+        try:
+            pending_ops = []
+            while True:
+                try:
+                    pending_ops.append(self._pending_ops.get_nowait())
+                except Empty:
+                    break
+
+            for action, window_name in pending_ops:
+                if action == "namedWindow" and window_name is not None:
+                    self._named_window_main_thread(window_name)
+                elif action == "destroyWindow" and window_name is not None:
+                    self._destroy_window_main_thread(window_name)
+                elif action == "destroyAllWindows":
+                    self._destroy_all_windows_main_thread()
+
+            with self._pending_lock:
+                pending_images = dict(self._pending_images)
+                self._pending_images.clear()
+
+            for window_name, image in pending_images.items():
+                self._imshow_main_thread(window_name, image)
+
+            if process_events and (pending_ops or pending_images):
+                self._process_events()
+        finally:
+            self._processing = False
+
+    def _imshow_main_thread(self, window_name: str, image: np.ndarray) -> None:
+        # Check if window exists but was closed by user
+        window = self.get_window(window_name)
+        if window is not None and not window.is_visible():
+            # Window was manually closed, remove and recreate
+            # This matches cv2 behavior where closing and re-imshow() works
+            self._destroy_window_main_thread(window_name)
+            window = None
+
+        # Create window if it doesn't exist
+        if window is None:
+            window = self.create_window(window_name)
+            window.show()
+
+        window.display(image)
+
+    def _named_window_main_thread(self, window_name: str) -> None:
+        self.create_window(window_name)
+
+    def _destroy_window_main_thread(self, window_name: str) -> None:
+        with self._lock:
+            window = self._windows.pop(window_name, None)
+            if window is not None:
+                window.close()
+
+    def _destroy_all_windows_main_thread(self) -> None:
+        with self._lock:
+            for window in self._windows.values():
+                window.close()
+            self._windows.clear()
+
+    def _process_events(self, delay_ms: int = 0) -> None:
+        app = QCoreApplication.instance()
+        if app is None or QThread.currentThread() != app.thread():
+            return
+
+        if delay_ms <= 0:
+            # Single event processing pass
+            app.processEvents(QEventLoop.ProcessEventsFlag.AllEvents)
+            return
+
+        # Process events for specified duration
+        start = time.perf_counter()
+        while (time.perf_counter() - start) * 1000 < delay_ms:
+            app.processEvents(QEventLoop.ProcessEventsFlag.AllEvents)
+            time.sleep(0.001)  # Minimal sleep to prevent CPU spinning
+
+
+# Module-level singleton
+_manager = WindowManager()
+
+
+# cv2-compatible API functions
+def namedWindow(window_name: str, flags: int = 0) -> None:
+    """Create a named window (cv2-compatible API).
+
+    Args:
+        window_name: Name of the window
+        flags: Ignored (for cv2 compatibility)
+    """
+    if _manager._on_main_thread():
+        _manager.create_window(window_name)
+    else:
+        _manager._pending_ops.put(("namedWindow", window_name))
+
+
+def imshow(window_name: str, image: np.ndarray) -> None:
+    """Display image in named window (cv2-compatible API).
+
+    Args:
+        window_name: Name of the window
+        image: HxW grayscale, HxWx3 BGR, or HxWx4 BGRA numpy array (uint8)
+
+    Note:
+        Assumes input is BGR (matching cv2 behavior).
+        If input is already RGB, colors will be swapped (red<->blue).
+    """
+    _manager.imshow(window_name, image)
+
+
+def waitKey(delay: int = 0) -> int:
+    """Process GUI events for specified milliseconds (cv2-compatible API).
+
+    Args:
+        delay: Delay in milliseconds (0 = single event pass)
+
+    Returns:
+        -1 (key support not implemented)
+    """
+    return _manager.wait_key(delay)
+
+
+def destroyWindow(window_name: str) -> None:
+    """Close and destroy named window (cv2-compatible API).
+
+    Args:
+        window_name: Name of the window to destroy
+    """
+    _manager.destroy_window(window_name)
+
+
+def destroyAllWindows() -> None:
+    """Close and destroy all windows (cv2-compatible API)."""
+    _manager.destroy_all_windows()
+
+
+def imshow_pump() -> None:
+    """Process queued imshow window operations on the main thread."""
+    _manager.process_pending()
+
+
+__all__ = [
+    "namedWindow",
+    "imshow",
+    "waitKey",
+    "destroyWindow",
+    "destroyAllWindows",
+    "imshow_pump",
+    "WindowManager",
+]

--- a/viewer/imshow_provider.py
+++ b/viewer/imshow_provider.py
@@ -1,0 +1,147 @@
+"""Qt Quick image provider for displaying OpenCV images via imshow()."""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable, Optional
+
+import numpy as np
+from PyQt6.QtCore import QSize
+from PyQt6.QtGui import QImage
+from PyQt6.QtQuick import QQuickImageProvider
+
+
+class ImshowImageProvider(QQuickImageProvider):
+    """Thread-safe provider for displaying numpy arrays in PyQt6 windows.
+
+    Simplified version of CameraImageProvider focused solely on displaying
+    static images without overlays, aruco, or robot integration.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(QQuickImageProvider.ImageType.Image)
+        self._lock = threading.Lock()
+        self._image: Optional[QImage] = None
+        self._notifier: Optional[Callable[[], None]] = None
+
+    def register_notifier(self, callback: Optional[Callable[[], None]]) -> None:
+        """Register callback to be notified when new image is available."""
+        self._notifier = callback
+
+    def update_image(self, image: np.ndarray) -> None:
+        """Update the displayed image.
+
+        Args:
+            image: HxW grayscale, HxWx3 BGR, or HxWx4 BGRA numpy array (uint8).
+                   BGR color order matches OpenCV convention.
+        """
+        if image is None or image.size == 0:
+            return  # Silently ignore like cv2
+
+        rgb = self._ensure_rgb(image)
+        qimage = self._qimage_from_rgb(rgb)
+
+        with self._lock:
+            self._image = qimage
+
+        self._notify()
+
+    def requestImage(self, image_id: str, *args):
+        """QQuickImageProvider interface - called by QML Image component."""
+        with self._lock:
+            image = self._clone_or_placeholder(self._image)
+
+        # Handle PyQt6 overload signatures
+        if len(args) == 1:  # size_out
+            size_out = args[0]
+            _update_size(size_out, image)
+            return image, image.size()
+        elif len(args) == 2:  # size_out, requested_size
+            size_out, _ = args
+            _update_size(size_out, image)
+            return image
+        return image
+
+    def _ensure_rgb(self, arr: np.ndarray) -> np.ndarray:
+        """Convert HxW grayscale or HxWx3 BGR to HxWx3 RGB.
+
+        NOTE: Assumes input is BGR (matching cv2 behavior).
+        If input is already RGB, colors will be swapped (red<->blue).
+
+        Args:
+            arr: Input numpy array
+
+        Returns:
+            HxWx3 RGB array (uint8, C-contiguous)
+
+        Raises:
+            ValueError: If array shape is not supported
+        """
+        arr = np.asarray(arr, dtype=np.uint8)
+
+        if arr.ndim == 2:
+            # Grayscale HxW -> RGB HxWx3
+            rgb = np.stack([arr, arr, arr], axis=-1)
+        elif arr.ndim == 3 and arr.shape[2] >= 3:
+            # BGR -> RGB (OpenCV uses BGR!)
+            # Also handles BGRA (HxWx4) by taking first 3 channels
+            rgb = arr[..., :3][..., ::-1]
+        else:
+            raise ValueError(
+                f"Expected HxW grayscale or HxWx3/HxWx4 BGR array, "
+                f"got shape {arr.shape}"
+            )
+
+        if not rgb.flags.c_contiguous:
+            rgb = np.ascontiguousarray(rgb)
+
+        return rgb.copy()
+
+    def _qimage_from_rgb(self, rgb: np.ndarray) -> QImage:
+        """Convert RGB numpy array to QImage.
+
+        CRITICAL: Must call image.copy() to detach from numpy buffer!
+        Otherwise QImage becomes invalid when numpy array is freed.
+
+        Args:
+            rgb: HxWx3 RGB array (uint8, C-contiguous)
+
+        Returns:
+            QImage with Format_RGB888
+        """
+        if rgb is None or rgb.ndim != 3:
+            raise ValueError("Expected RGB array for conversion")
+
+        height, width = rgb.shape[:2]
+        bytes_per_line = width * 3
+        image = QImage(
+            rgb.data, width, height, bytes_per_line, QImage.Format.Format_RGB888
+        )
+        return image.copy()  # CRITICAL: detach from numpy buffer
+
+    @staticmethod
+    def _clone_or_placeholder(image: Optional[QImage]) -> QImage:
+        """Return a copy of the image or a placeholder if None."""
+        if image is None or image.isNull():
+            # Return 1x1 black image as placeholder
+            placeholder = QImage(1, 1, QImage.Format.Format_RGB888)
+            placeholder.fill(0)
+            return placeholder
+        return image.copy()
+
+    def _notify(self) -> None:
+        """Trigger notifier callback if registered."""
+        callback = self._notifier
+        if callback is None:
+            return
+        try:
+            callback()
+        except Exception:
+            pass  # Silently ignore callback errors
+
+
+def _update_size(size_out: QSize, image: QImage) -> None:
+    """Update QSize with image dimensions."""
+    if size_out is not None:
+        size_out.setWidth(image.width())
+        size_out.setHeight(image.height())

--- a/viewer/imshow_window.py
+++ b/viewer/imshow_window.py
@@ -1,0 +1,112 @@
+"""QtQuick-based window for displaying OpenCV images via imshow()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from PyQt6.QtCore import QMetaObject, QObject, Qt, QUrl, pyqtSlot
+from PyQt6.QtGui import QGuiApplication
+from PyQt6.QtQml import QQmlContext
+from PyQt6.QtQuick import QQuickView
+
+from .imshow_provider import ImshowImageProvider
+
+
+class ImshowWindow(QObject):
+    """Window wrapper for displaying numpy arrays using PyQt6.
+
+    Simplified version of CamViewer focused on displaying static images
+    without polling, snapshots, or complex state management.
+    """
+
+    def __init__(self, window_name: str, width: int = 640, height: int = 480) -> None:
+        """Initialize imshow window.
+
+        Args:
+            window_name: Name displayed in window title bar
+            width: Initial window width
+            height: Initial window height
+        """
+        super().__init__(parent=None)
+
+        self._window_name = window_name
+        self._width = width
+        self._height = height
+
+        # Get or create QGuiApplication singleton
+        self._app = QGuiApplication.instance() or QGuiApplication([])
+
+        self._provider = ImshowImageProvider()
+        self._provider.register_notifier(self._queue_frame_bump)
+
+        self._frame_counter = 0
+
+        # Setup QQuickView
+        self._view = QQuickView()
+        self._view.setResizeMode(QQuickView.ResizeMode.SizeRootObjectToView)
+        self._view.setTitle(window_name)
+
+        self._context = self._initialize_qml_context()
+
+    def _initialize_qml_context(self) -> QQmlContext:
+        """Initialize QML context with image provider and properties."""
+        repo_root = Path(__file__).resolve().parents[1]
+        qml_path = (repo_root / "qml" / "SimpleImshow.qml").resolve()
+
+        engine = self._view.engine()
+        engine.addImportPath(str(repo_root / "qml"))
+        engine.addImageProvider("imshow", self._provider)
+
+        context = self._view.rootContext()
+        context.setContextProperty("frameId", self._frame_counter)
+
+        self._view.setSource(QUrl.fromLocalFile(str(qml_path)))
+
+        return context
+
+    def show(self) -> None:
+        """Display the window."""
+        self._view.setWidth(self._width)
+        self._view.setHeight(self._height)
+        self._view.show()
+
+    def close(self) -> None:
+        """Close the window."""
+        self._view.close()
+
+    def display(self, image: np.ndarray) -> None:
+        """Update displayed image.
+
+        Args:
+            image: HxW grayscale, HxWx3 BGR, or HxWx4 BGRA numpy array (uint8)
+        """
+        self._provider.update_image(image)
+
+    def is_visible(self) -> bool:
+        """Check if window is currently visible."""
+        return self._view.isVisible()
+
+    def _queue_frame_bump(self) -> None:
+        """Schedule frame counter increment (thread-safe).
+
+        Uses QMetaObject.invokeMethod with QueuedConnection to explicitly
+        guarantee execution on the Qt GUI thread, regardless of which thread
+        calls this method.
+        """
+        if QGuiApplication.instance() is None:
+            self._increment_frame()
+        else:
+            QMetaObject.invokeMethod(
+                self, "_increment_frame", Qt.ConnectionType.QueuedConnection
+            )
+
+    @pyqtSlot()
+    def _increment_frame(self) -> None:
+        """Increment frame counter to trigger QML refresh.
+
+        This causes QML to re-request the image from the provider.
+        """
+        self._frame_counter += 1
+        if self._context is not None:
+            self._context.setContextProperty("frameId", self._frame_counter)

--- a/viewer/path_model.py
+++ b/viewer/path_model.py
@@ -117,6 +117,8 @@ class WavefrontFrame:
     square_size_mm: float
     goal_marker: int
     max_value: int
+    origin_x: float
+    origin_y: float
 
     def copy(self) -> "WavefrontFrame":
         return WavefrontFrame(
@@ -124,6 +126,8 @@ class WavefrontFrame:
             square_size_mm=self.square_size_mm,
             goal_marker=self.goal_marker,
             max_value=self.max_value,
+            origin_x=self.origin_x,
+            origin_y=self.origin_y,
         )
 
 
@@ -727,11 +731,23 @@ class PathSceneProvider:
             grid = np.array(wf.grid, copy=True)
             unique_vals = np.unique(grid)
             max_value = int(unique_vals[-2]) if unique_vals.size >= 2 else int(unique_vals[-1]) if unique_vals.size else 0
+            square_size = float(getattr(wf, "square_size", 5.0))
+            inflate = float(getattr(wf, "inflate_size", 0.0))
+            origin_x = 0.0
+            origin_y = 0.0
+            bbox = getattr(wf, "bbox", None)
+            if bbox is not None and grid.size > 0:
+                rows = grid.shape[1]
+                if rows > 0:
+                    origin_x = float(bbox[0][0]) - 2.0 * inflate
+                    origin_y = float(bbox[0][1]) - 2.0 * inflate + (rows - 1) * square_size
             wavefront_frame = WavefrontFrame(
                 grid=grid,
-                square_size_mm=float(getattr(wf, "square_size", 5.0)),
+                square_size_mm=square_size,
                 goal_marker=int(getattr(WaveFront, "goal_marker", 2**31 - 1)),
                 max_value=max_value,
+                origin_x=origin_x,
+                origin_y=origin_y,
             )
 
         bounds = Bounds.from_points(bounds_x, bounds_y)

--- a/viewer/path_viewer.py
+++ b/viewer/path_viewer.py
@@ -14,11 +14,13 @@ from aim_fsm.rrt import RRT
 
 from .help_texts import PATH_HELP_TEXT
 from .path_model import (
+    CircleItem,
     PathNodeModel,
     PathObstacleModel,
     PathPolylineModel,
     PathSceneProvider,
     PathSceneSnapshot,
+    RectangleItem,
     WavefrontTextureProvider,
 )
 
@@ -110,6 +112,8 @@ class PathViewer(QObject):
         self._wavefront_provider = WavefrontTextureProvider()
         self._wavefront_source = ""
         self._wavefront_square_size = 5.0
+        self._wavefront_origin_x = 0.0
+        self._wavefront_origin_y = 0.0
         self._scene_snapshot: PathSceneSnapshot = PathSceneSnapshot.empty()
         self._view_state = PathViewState()
         self._help_text = PATH_HELP_TEXT
@@ -144,6 +148,14 @@ class PathViewer(QObject):
     def wavefrontSquareSize(self) -> float:
         return self._wavefront_square_size
 
+    @pyqtProperty(float, notify=sceneChanged)
+    def wavefrontOriginX(self) -> float:
+        return self._wavefront_origin_x
+
+    @pyqtProperty(float, notify=sceneChanged)
+    def wavefrontOriginY(self) -> float:
+        return self._wavefront_origin_y
+
     @pyqtProperty(str, notify=sceneChanged)
     def statusText(self) -> str:
         return self._scene_snapshot.status_text or ""
@@ -166,6 +178,22 @@ class PathViewer(QObject):
 
     def clear(self) -> None:
         self._scene_provider.clear_extra_trees()
+        rrt = self._rrt or getattr(self._robot, "rrt", None)
+        if rrt is not None:
+            rrt.treeA = []
+            rrt.treeB = []
+            rrt.path = []
+            rrt.draw_path = []
+            rrt.obstacles = []
+            rrt.goal_obstacle = None
+            rrt.grid_display = None
+            rrt.text = None
+        path_planner = getattr(self._robot, "path_planner", None)
+        if path_planner is not None:
+            try:
+                path_planner.wf = None
+            except Exception:
+                pass
         self.refresh()
 
     def add_tree(self, tree, color) -> None:
@@ -195,6 +223,12 @@ class PathViewer(QObject):
         source_key, square_size = self._wavefront_provider.update_frame(snapshot.wavefront)
         self._wavefront_source = f"image://wavefront/{source_key}" if source_key else ""
         self._wavefront_square_size = square_size
+        if snapshot.wavefront is not None:
+            self._wavefront_origin_x = float(snapshot.wavefront.origin_x)
+            self._wavefront_origin_y = float(snapshot.wavefront.origin_y)
+        else:
+            self._wavefront_origin_x = 0.0
+            self._wavefront_origin_y = 0.0
 
         self.sceneChanged.emit()
 
@@ -299,6 +333,36 @@ class PathViewer(QObject):
             return
         if root is not None and hasattr(root, "forceActiveFocus"):
             root.forceActiveFocus()
+
+    @staticmethod
+    def _shape_dict(item: CircleItem | RectangleItem) -> dict:
+        if isinstance(item, CircleItem):
+            return {
+                "type": "circle",
+                "x": float(item.x),
+                "y": float(item.y),
+                "radius": float(item.radius_mm),
+                "width": 0.0,
+                "height": 0.0,
+                "rotation": 0.0,
+                "color": list(item.color_rgba),
+                "filled": bool(item.filled),
+                "tag": item.tag or "",
+            }
+        if isinstance(item, RectangleItem):
+            return {
+                "type": "rectangle",
+                "x": float(item.x),
+                "y": float(item.y),
+                "radius": 0.0,
+                "width": float(item.width_mm),
+                "height": float(item.height_mm),
+                "rotation": float(item.rotation_deg),
+                "color": list(item.color_rgba),
+                "filled": bool(item.filled),
+                "tag": item.tag or "",
+            }
+        return {}
 
     # ------------------------------------------------------------------
     # Data access for QML (temporary getters until models exist)


### PR DESCRIPTION
Summary
- PyQt6-based cv2-style window functions (namedWindow/imshow/waitKey/destroyWindow/destroyAllWindows)
- ArUco annotation display fix
- PathViewer fixes: arrow-key panning moves both halves together; clear() fully clears both displays
- aim_fsm/program.py: added an annotated_image_callback hook for applications that need annotated frames without opening a camera viewer