### PR TITLE
Camera viewer tweaks: red ArUco IDs, RGB imshow, correct user_annotate ordering

### DIFF
--- a/aim_fsm/__init__.py
+++ b/aim_fsm/__init__.py
@@ -24,11 +24,10 @@ from viewer.worldmap_viewer import WorldMapViewer
 from viewer.particle_viewer import ParticleViewer
 from viewer.path_viewer import PathViewer
 
-# PyQt6 imshow() API - cv2-compatible functions
+# PyQt6 imshow() API - cv2-style functions
 from viewer import (
     namedWindow,
     imshow,
-    waitKey,
     destroyWindow,
     destroyAllWindows,
 )

--- a/aim_fsm/aruco.py
+++ b/aim_fsm/aruco.py
@@ -125,7 +125,29 @@ class RobotArucoDetector(object):
         base = image.copy()
         overlay = np.zeros_like(base)
         overlay_bgr = cv2.cvtColor(overlay, cv2.COLOR_RGB2BGR)
-        cv2.aruco.drawDetectedMarkers(overlay_bgr, scaled_corners, self.ids)
+        cv2.aruco.drawDetectedMarkers(overlay_bgr, scaled_corners)
+        if self.ids is not None:
+            try:
+                for idx, marker_id in enumerate(self.ids):
+                    corners = np.asarray(scaled_corners[idx]).reshape(-1, 2)
+                    if corners.size == 0:
+                        continue
+                    x, y = corners[0]
+                    x = max(0, int(round(x)) + 4)
+                    y = max(0, int(round(y)) - 6)
+                    marker_id = int(np.asarray(marker_id).reshape(-1)[0])
+                    cv2.putText(
+                        overlay_bgr,
+                        str(marker_id),
+                        (x, y),
+                        cv2.FONT_HERSHEY_SIMPLEX,
+                        0.6,
+                        (0, 0, 255),
+                        thickness=2,
+                        lineType=cv2.LINE_AA,
+                    )
+            except Exception:
+                pass
         overlay_rgb = cv2.cvtColor(overlay_bgr, cv2.COLOR_BGR2RGB)
         mask = np.any(overlay_rgb != 0, axis=2)
         base[mask] = overlay_rgb[mask]

--- a/aim_fsm/program.py
+++ b/aim_fsm/program.py
@@ -10,6 +10,7 @@ except:
         print(string)
 
 import cv2
+import numpy as _np
 
 import vex
 from . import evbase
@@ -243,8 +244,13 @@ class StateMachineProgram(StateNode):
             overlay_status,
             int(AIVISION_RESOLUTION_SCALE) or 1,
             getattr(self.robot, "aruco_detector", None),
-            self.user_annotate,
         )
+        try:
+            maybe = self.user_annotate(annotated)
+            if isinstance(maybe, _np.ndarray) and maybe.ndim == 3:
+                annotated = maybe
+        except Exception:
+            pass
         try:
             self.robot.annotated_image = annotated.copy()
         except Exception:
@@ -257,7 +263,7 @@ class StateMachineProgram(StateNode):
 
     def process_image(self,image):
         # Aruco image processing
-        gray = cv2.cvtColor(image,cv2.COLOR_BGR2GRAY)
+        gray = cv2.cvtColor(image,cv2.COLOR_RGB2GRAY)
         if self.aruco:
             self.robot.aruco_detector.process_image(gray)
         # Other image processors can run here if the user supplies them.
@@ -265,7 +271,24 @@ class StateMachineProgram(StateNode):
         if self.annotated_image_callback is not None:
             self._emit_annotated_frame(image)
         elif self.force_annotation and not self.robot.cam_viewer:
-            self.user_annotate(image)
+            status = getattr(self.robot, "status", None)
+            overlay_status = status if self.annotate_sdk else None
+            annotated = apply_overlays(
+                image,
+                overlay_status,
+                int(AIVISION_RESOLUTION_SCALE) or 1,
+                getattr(self.robot, "aruco_detector", None),
+            )
+            try:
+                maybe = self.user_annotate(annotated)
+                if isinstance(maybe, _np.ndarray) and maybe.ndim == 3:
+                    annotated = maybe
+            except Exception:
+                pass
+            try:
+                self.robot.annotated_image = annotated.copy()
+            except Exception:
+                pass
 
 ################
 

--- a/viewer/__init__.py
+++ b/viewer/__init__.py
@@ -22,7 +22,6 @@ __all__ = [
     # PyQt6 imshow() API
     "namedWindow",
     "imshow",
-    "waitKey",
     "destroyWindow",
     "destroyAllWindows",
     "ImshowImageProvider",
@@ -48,7 +47,6 @@ _MODULE_MAP = {
     # PyQt6 imshow() API
     "namedWindow": ("viewer.imshow_manager", "namedWindow"),
     "imshow": ("viewer.imshow_manager", "imshow"),
-    "waitKey": ("viewer.imshow_manager", "waitKey"),
     "destroyWindow": ("viewer.imshow_manager", "destroyWindow"),
     "destroyAllWindows": ("viewer.imshow_manager", "destroyAllWindows"),
     "ImshowImageProvider": ("viewer.imshow_provider", "ImshowImageProvider"),

--- a/viewer/camera_overlay.py
+++ b/viewer/camera_overlay.py
@@ -121,7 +121,6 @@ def apply_overlays(
     status: Optional[dict],
     scale: int,
     aruco_detector: Optional[object],
-    user_hook: Optional[object],
 ) -> _np.ndarray:
     if image_rgb is None or image_rgb.ndim != 3:
         return image_rgb
@@ -160,14 +159,6 @@ def apply_overlays(
                 maybe = aruco_detector.annotate(out, scale)
                 if isinstance(maybe, _np.ndarray) and maybe.ndim == 3:
                     out = maybe
-        except Exception:
-            pass
-
-    if user_hook is not None:
-        try:
-            maybe = user_hook(out)
-            if isinstance(maybe, _np.ndarray) and maybe.ndim == 3:
-                out = maybe
         except Exception:
             pass
 

--- a/viewer/camera_provider.py
+++ b/viewer/camera_provider.py
@@ -152,22 +152,27 @@ class CameraImageProvider(QQuickImageProvider):
 
         status = self._resolve_status()
 
-        overlays_requested = bool(
-            (status or {}).get("aivision") or self._aruco_detector or self._user_hook
-        )
+        overlays_requested = bool((status or {}).get("aivision") or self._aruco_detector)
         if overlays_requested:
             maybe = apply_overlays(
                 annotated,
                 status,
                 int(AIVISION_RESOLUTION_SCALE) or 1,
                 self._aruco_detector,
-                self._user_hook,
             )
             if isinstance(maybe, _np.ndarray) and maybe.ndim == 3:
                 annotated = maybe.copy()
 
         if self._crosshair_enabled:
             self._apply_crosshair(annotated)
+
+        if self._user_hook is not None:
+            try:
+                maybe = self._user_hook(annotated)
+                if isinstance(maybe, _np.ndarray) and maybe.ndim == 3:
+                    annotated = maybe.copy()
+            except Exception:
+                pass
 
         return annotated
 

--- a/viewer/imshow_manager.py
+++ b/viewer/imshow_manager.py
@@ -1,4 +1,4 @@
-"""Global window manager and cv2-compatible API for PyQt6 imshow()."""
+"""Global window manager and cv2-style API for PyQt6 imshow()."""
 
 from __future__ import annotations
 
@@ -87,7 +87,7 @@ class WindowManager:
 
         Args:
             window_name: Name of the window
-            image: HxW grayscale, HxWx3 BGR, or HxWx4 BGRA numpy array (uint8)
+            image: HxW grayscale, HxWx3 RGB, or HxWx4 RGBA numpy array (uint8)
         """
         if not self._on_main_thread():
             window = self.get_window(window_name)
@@ -100,20 +100,6 @@ class WindowManager:
             return
         self._imshow_main_thread(window_name, image)
         self._process_events()
-
-    def wait_key(self, delay_ms: int = 0) -> int:
-        """Process Qt events briefly.
-
-        Args:
-            delay_ms: Delay in milliseconds (0 = single event pass)
-
-        Returns:
-            -1 (key support not implemented)
-        """
-        if self._on_main_thread():
-            self.process_pending()
-        self._process_events(delay_ms)
-        return -1  # No key support
 
     def process_pending(self, process_events: bool = True) -> None:
         if not self._on_main_thread():
@@ -201,7 +187,7 @@ class WindowManager:
 _manager = WindowManager()
 
 
-# cv2-compatible API functions
+# cv2-style API functions
 def namedWindow(window_name: str, flags: int = 0) -> None:
     """Create a named window (cv2-compatible API).
 
@@ -220,25 +206,9 @@ def imshow(window_name: str, image: np.ndarray) -> None:
 
     Args:
         window_name: Name of the window
-        image: HxW grayscale, HxWx3 BGR, or HxWx4 BGRA numpy array (uint8)
-
-    Note:
-        Assumes input is BGR (matching cv2 behavior).
-        If input is already RGB, colors will be swapped (red<->blue).
+        image: HxW grayscale, HxWx3 RGB, or HxWx4 RGBA numpy array (uint8)
     """
     _manager.imshow(window_name, image)
-
-
-def waitKey(delay: int = 0) -> int:
-    """Process GUI events for specified milliseconds (cv2-compatible API).
-
-    Args:
-        delay: Delay in milliseconds (0 = single event pass)
-
-    Returns:
-        -1 (key support not implemented)
-    """
-    return _manager.wait_key(delay)
 
 
 def destroyWindow(window_name: str) -> None:
@@ -263,7 +233,6 @@ def imshow_pump() -> None:
 __all__ = [
     "namedWindow",
     "imshow",
-    "waitKey",
     "destroyWindow",
     "destroyAllWindows",
     "imshow_pump",

--- a/viewer/imshow_provider.py
+++ b/viewer/imshow_provider.py
@@ -1,4 +1,4 @@
-"""Qt Quick image provider for displaying OpenCV images via imshow()."""
+"""Qt Quick image provider for displaying RGB numpy images via imshow()."""
 
 from __future__ import annotations
 
@@ -32,8 +32,8 @@ class ImshowImageProvider(QQuickImageProvider):
         """Update the displayed image.
 
         Args:
-            image: HxW grayscale, HxWx3 BGR, or HxWx4 BGRA numpy array (uint8).
-                   BGR color order matches OpenCV convention.
+            image: HxW grayscale, HxWx3 RGB, or HxWx4 RGBA numpy array (uint8).
+                   RGB color order matches the rest of vex-aim-tools.
         """
         if image is None or image.size == 0:
             return  # Silently ignore like cv2
@@ -63,10 +63,9 @@ class ImshowImageProvider(QQuickImageProvider):
         return image
 
     def _ensure_rgb(self, arr: np.ndarray) -> np.ndarray:
-        """Convert HxW grayscale or HxWx3 BGR to HxWx3 RGB.
+        """Convert HxW grayscale or HxWx3 RGB to HxWx3 RGB.
 
-        NOTE: Assumes input is BGR (matching cv2 behavior).
-        If input is already RGB, colors will be swapped (red<->blue).
+        NOTE: Assumes input is RGB.
 
         Args:
             arr: Input numpy array
@@ -83,12 +82,11 @@ class ImshowImageProvider(QQuickImageProvider):
             # Grayscale HxW -> RGB HxWx3
             rgb = np.stack([arr, arr, arr], axis=-1)
         elif arr.ndim == 3 and arr.shape[2] >= 3:
-            # BGR -> RGB (OpenCV uses BGR!)
-            # Also handles BGRA (HxWx4) by taking first 3 channels
-            rgb = arr[..., :3][..., ::-1]
+            # RGB (or RGBA -> RGB by dropping alpha)
+            rgb = arr[..., :3]
         else:
             raise ValueError(
-                f"Expected HxW grayscale or HxWx3/HxWx4 BGR array, "
+                f"Expected HxW grayscale or HxWx3/HxWx4 RGB array, "
                 f"got shape {arr.shape}"
             )
 

--- a/viewer/imshow_window.py
+++ b/viewer/imshow_window.py
@@ -1,4 +1,4 @@
-"""QtQuick-based window for displaying OpenCV images via imshow()."""
+"""QtQuick-based window for displaying RGB numpy images via imshow()."""
 
 from __future__ import annotations
 
@@ -79,7 +79,7 @@ class ImshowWindow(QObject):
         """Update displayed image.
 
         Args:
-            image: HxW grayscale, HxWx3 BGR, or HxWx4 BGRA numpy array (uint8)
+            image: HxW grayscale, HxWx3 RGB, or HxWx4 RGBA numpy array (uint8)
         """
         self._provider.update_image(image)
 


### PR DESCRIPTION
- Draw ArUco marker IDs in bright red for better readability. (aim_fsm/aruco.py)
- Make imshow consistently use RGB input, remove RGB/BGR swapping, and remove the no-op waitKey. (viewer/imshow_provider.py, viewer/imshow_manager.py, viewer/imshow_window.py, viewer/__init__.py, aim_fsm/__init__.py)
- Ensure user_annotate() is called after SDK and ArUco annotations, and treat its return value as the final image for both display and annotated_image_callback. (viewer/camera_provider.py, viewer/camera_overlay.py, aim_fsm/program.py)
- Fix grayscale conversion in process_image to use RGB->GRAY to match the camera image format. (aim_fsm/program.py)
  