### PR TITLE
Fix worldmap viewer display bugs + viewer improvements

### DIFF
--- a/aim_fsm/aruco.py
+++ b/aim_fsm/aruco.py
@@ -2,6 +2,7 @@ try: import cv2
 except: pass
 
 import math
+import threading
 from math import pi
 
 import numpy as np
@@ -45,6 +46,7 @@ class ArucoMarker(object):
 class RobotArucoDetector(object):
     def __init__(self, robot, dictionary_name, marker_size=ARUCO_MARKER_SIZE, disabled_ids=[]):
         self.robot = robot
+        self._lock = threading.RLock()
         dictionary = cv2.aruco.getPredefinedDictionary(dictionary_name)
         detector_params = cv2.aruco.DetectorParameters()
         self.detector = cv2.aruco.ArucoDetector(dictionary, detector_params)
@@ -63,16 +65,24 @@ class RobotArucoDetector(object):
             ], dtype=np.float32)
 
     def process_image(self,gray):
-        self.seen_marker_ids = []
-        self.seen_marker_objects = dict()
-        self._last_image_shape = gray.shape[:2]
-        (self.corners, self.ids, _) = self.detector.detectMarkers(gray)
-        if self.ids is None: return
+        seen_marker_ids = []
+        seen_marker_objects = dict()
+        last_image_shape = gray.shape[:2]
+        corners, ids, _ = self.detector.detectMarkers(gray)
+
+        if ids is None:
+            with self._lock:
+                self.seen_marker_ids = seen_marker_ids
+                self.seen_marker_objects = seen_marker_objects
+                self._last_image_shape = last_image_shape
+                self.corners = []
+                self.ids = None
+            return
 
         # Estimate poses
-        for i in range(len(self.corners)):
-            image_corners = self.corners[i]
-            id = int(self.ids[i][0])
+        for i in range(len(corners)):
+            image_corners = corners[i]
+            id = int(ids[i][0])
             try:
                 success, rvec, tvec = cv2.solvePnP(self.object_corners,
                                                    image_corners,
@@ -80,7 +90,7 @@ class RobotArucoDetector(object):
                                                    self.robot.camera.distortion_array)
             except Exception as e:
                 print(f'Aruco detector: solvePnP failed:', e)
-                return
+                continue
             if id in self.disabled_ids: continue
             if rvec[2][0] > math.pi/2 or rvec[2][0] < -math.pi/2:
                 # can't see a marker facing away from us, so bogus
@@ -88,14 +98,32 @@ class RobotArucoDetector(object):
                       f'rvec={(rvec*180/pi).tolist()}')
                 continue
             marker = ArucoMarker(self, id, image_corners, tvec, rvec)
-            self.seen_marker_ids.append(id)
-            self.seen_marker_objects[id] = marker
+            seen_marker_ids.append(id)
+            seen_marker_objects[id] = marker
 
-    def _scale_corners(self, scale_x, scale_y):
+        with self._lock:
+            self.seen_marker_ids = seen_marker_ids
+            self.seen_marker_objects = seen_marker_objects
+            self._last_image_shape = last_image_shape
+            self.corners = corners
+            self.ids = ids
+
+    def snapshot_seen_markers(self):
+        with self._lock:
+            return dict(self.seen_marker_objects)
+
+    def snapshot_annotation_state(self):
+        with self._lock:
+            corners = list(self.corners) if self.corners else []
+            ids = None if self.ids is None else np.array(self.ids, copy=True)
+            image_shape = self._last_image_shape
+        return corners, ids, image_shape
+
+    def _scale_corners(self, corners, scale_x, scale_y):
         if scale_x == 1.0 and scale_y == 1.0:
-            return self.corners
+            return corners
         scaled = []
-        for corner in self.corners:
+        for corner in corners:
             scaled_corner = corner.copy()
             scaled_corner[..., 0] = scaled_corner[..., 0] * scale_x
             scaled_corner[..., 1] = scaled_corner[..., 1] * scale_y
@@ -103,7 +131,8 @@ class RobotArucoDetector(object):
         return scaled
 
     def annotate(self, image, scale_factor=1):
-        if image is None or self.ids is None or not self.corners:
+        corners, ids, image_shape = self.snapshot_annotation_state()
+        if image is None or ids is None or not corners:
             return image
         if not hasattr(cv2, "aruco"):
             return image
@@ -111,8 +140,8 @@ class RobotArucoDetector(object):
         height, width = image.shape[:2]
         scale_x = 1.0
         scale_y = 1.0
-        if self._last_image_shape is not None:
-            src_h, src_w = self._last_image_shape
+        if image_shape is not None:
+            src_h, src_w = image_shape
             if src_h and src_w and (src_h != height or src_w != width):
                 scale_x = width / src_w
                 scale_y = height / src_h
@@ -120,19 +149,19 @@ class RobotArucoDetector(object):
             scale_x = float(scale_factor)
             scale_y = float(scale_factor)
 
-        scaled_corners = self._scale_corners(scale_x, scale_y)
+        scaled_corners = self._scale_corners(corners, scale_x, scale_y)
 
         base = image.copy()
         overlay = np.zeros_like(base)
         overlay_bgr = cv2.cvtColor(overlay, cv2.COLOR_RGB2BGR)
         cv2.aruco.drawDetectedMarkers(overlay_bgr, scaled_corners)
-        if self.ids is not None:
+        if ids is not None:
             try:
-                for idx, marker_id in enumerate(self.ids):
-                    corners = np.asarray(scaled_corners[idx]).reshape(-1, 2)
-                    if corners.size == 0:
+                for idx, marker_id in enumerate(ids):
+                    marker_corners = np.asarray(scaled_corners[idx]).reshape(-1, 2)
+                    if marker_corners.size == 0:
                         continue
-                    x, y = corners[0]
+                    x, y = marker_corners[0]
                     x = max(0, int(round(x)) + 4)
                     y = max(0, int(round(y)) - 6)
                     marker_id = int(np.asarray(marker_id).reshape(-1)[0])

--- a/aim_fsm/worldmap.py
+++ b/aim_fsm/worldmap.py
@@ -1,7 +1,9 @@
 import math
+import copy
 import numpy as np
 import time
 import datetime
+import threading
 import cv2
 
 from .geometry import *
@@ -235,6 +237,7 @@ class WorldMap():
 
     def __init__(self,robot):
         self.robot = robot
+        self._lock = threading.RLock()
         self.objects = dict()
         self.pending_objects = dict()
         self.missing_objects = []
@@ -244,34 +247,56 @@ class WorldMap():
         self.visibility_paused = False
 
     def __repr__(self):
-        return f'<WorldMap with {len(self.objects)} objects>'
+        with self._lock:
+            count = len(self.objects)
+        return f'<WorldMap with {count} objects>'
+
+    def snapshot_objects(self):
+        with self._lock:
+            snapshot = {}
+            for key, obj in self.objects.items():
+                try:
+                    cloned = copy.copy(obj)
+                    pose = getattr(obj, "pose", None)
+                    if pose is not None:
+                        try:
+                            cloned.pose = PoseEstimate(pose)
+                        except Exception:
+                            cloned.pose = copy.copy(pose)
+                    snapshot[key] = cloned
+                except Exception:
+                    snapshot[key] = obj
+            return snapshot
 
     def clear(self):
-        self.robot.particle_filter.clear_landmarks()
-        self.objects.clear()
-        self.pending_objects.clear()
-        self.missing_objects = []
-        self.shared_objects.clear()
-        self.name_counts.clear()
+        with self._lock:
+            self.robot.particle_filter.clear_landmarks()
+            self.objects.clear()
+            self.pending_objects.clear()
+            self.missing_objects = []
+            self.shared_objects.clear()
+            self.name_counts.clear()
         
     def pause_visibility(self, value=True):
         """Turn off visibility of objects when the robot is moving.  We won't
         turn it back on until the robot has stopped AND we have processed a new
         camera frame so visibilities are updated."""
-        if self.visibility_paused != value:
-            self.visibility_paused = value
+        with self._lock:
+            if self.visibility_paused != value:
+                self.visibility_paused = value
 
     def update(self):
-        if self.visibility_paused:
-            return
-        self.updated_objects = []
-        self.make_new_objects_from_vision()
-        self.associate_objects()
-        self.update_associated_objects()
-        self.detect_missing_objects()
-        self.process_unassociated_objects()
-        self.update_visibilities()
-        self.update_holding()
+        with self._lock:
+            if self.visibility_paused:
+                return
+            self.updated_objects = []
+            self.make_new_objects_from_vision()
+            self.associate_objects()
+            self.update_associated_objects()
+            self.detect_missing_objects()
+            self.process_unassociated_objects()
+            self.update_visibilities()
+            self.update_holding()
 
     def make_new_objects_from_vision(self):
         self.candidates = list()
@@ -355,7 +380,12 @@ class WorldMap():
 
     def make_new_aruco_objects(self):
         camera_offset_vector = np.array([0, 0, self.robot.kine.camera_from_origin])
-        for (id,marker) in self.robot.aruco_detector.seen_marker_objects.copy().items():
+        detector = self.robot.aruco_detector
+        if hasattr(detector, "snapshot_seen_markers"):
+            seen_markers = detector.snapshot_seen_markers()
+        else:
+            seen_markers = detector.seen_marker_objects.copy()
+        for (id,marker) in seen_markers.items():
             name = f'ArucoMarker-{id}'
             spec = {'name': name, 'id': id, 'marker': marker}
             sensor_coords = marker.camera_coords + camera_offset_vector
@@ -375,7 +405,11 @@ class WorldMap():
             self.candidates.append(obj)
 
     def make_new_wall_objects(self):
-        seen = self.robot.aruco_detector.seen_marker_objects.copy()
+        detector = self.robot.aruco_detector
+        if hasattr(detector, "snapshot_seen_markers"):
+            seen = detector.snapshot_seen_markers()
+        else:
+            seen = detector.seen_marker_objects.copy()
         wall_markers = dict()
         for (id,marker) in seen.items():
             if id in self.robot.world_map.wall_marker_dict:
@@ -412,12 +446,14 @@ class WorldMap():
                 if len(orients) < 2:
                     print('outlier removal left us one marker:', markers)
             wall = self.infer_wall_from_corners_lists(wall_id, markers)
+            if wall is None:
+                continue
             wall.aruco_orients = orients
             wall.seen_markers = markers
             self.candidates.append(wall)
             #print('candidate:', wall, 'orients(deg)=', [o*180/pi for o in orients])
             # Don't make doorways until wall is confirmed in world map
-            if [k for k in self.robot.world_map.objects.keys() if k.startswith(wall.name)]:
+            if [k for k in self.objects.keys() if k.startswith(wall.name)]:
                 self.make_doorways_from_wall(wall)
 
     def infer_wall_from_corners_lists(self, wall_id, markers):
@@ -425,6 +461,7 @@ class WorldMap():
         marker_size = self.robot.aruco_detector.marker_size
         world_points = []
         image_points = []
+        last_solution = None
         for (id, marker) in markers:
             length = wall_spec.length
             side = wall_spec.marker_specs[id]['side']
@@ -452,6 +489,11 @@ class WorldMap():
                       'world_points=', world_points, '\n',
                       'image_points=', image_points)
                 continue
+            if success:
+                last_solution = (rvec, tvec, side)
+        if last_solution is None:
+            return None
+        rvec, tvec, side = last_solution
         rotationm, jacob = cv2.Rodrigues(rvec)
         euler_angles = rotation_matrix_to_euler_angles(rotationm)
         wall_orient = euler_angles[1]
@@ -524,6 +566,8 @@ class WorldMap():
         for i in range(N_new):
             for j in range(N_old):
                 if otype is ArucoMarkerObj and new[i].marker_id != old[j].marker_id:
+                    costs[i,j] = MAX_ACCEPTABLE_COST + 1
+                elif otype is AprilTagObj and new[i].tag_id != old[j].tag_id:
                     costs[i,j] = MAX_ACCEPTABLE_COST + 1
                 else:
                     costs[i,j] = self.association_cost(new[i], old[j])
@@ -614,16 +658,18 @@ class WorldMap():
         missing = [m for m in self.missing_objects if type(m) == t]
         if hasattr(obj,'marker_id'):
             missing = [m for m in missing if m.marker_id == obj.marker_id]
+        if hasattr(obj,'tag_id'):
+            missing = [m for m in missing if m.tag_id == obj.tag_id]
         if len(missing) == 0:
             return None
         costs = [self.association_cost(obj, m) for m in missing]
         min_index = np.argmin(costs)
         match = missing[min_index]
         match.is_visible = True
+        match.is_missing = False
         match.pose = PoseEstimate(obj.pose)
         self.updated_objects.append(match)
         self.missing_objects.remove(match)
-        match.is_visible = True
         #print('reclaimed', match)
         return match
         
@@ -670,7 +716,7 @@ class WorldMap():
     def confirm_not_holding(self):
         if self.robot.robot0.has_any_barrel() or self.robot.robot0.has_sports_ball():
             held_obj = None
-            for obj in self.robot.world_map.objects.values():
+            for obj in self.objects.values():
                 if isinstance(obj, (BarrelObj,SportsBallObj)):
                     spec = obj.spec
                     if isinstance(obj, BarrelObj):
@@ -697,59 +743,61 @@ class WorldMap():
             self.robot.holding.pose.y = self.robot.pose.y + pt[1,0]
 
     def show_objects(self):
-        objs = sorted(self.objects.items(), key=lambda x: x[0])
-        if len(objs) == 0:
-            print('No objects in the world map.\n')
-            return
-        width = max([len(x[0]) for x in objs])
-        for obj in objs:
-            print(f'{obj[0].rjust(width)}: {obj[1]}')
-        print()
+        with self._lock:
+            objs = sorted(self.objects.items(), key=lambda x: x[0])
+            if len(objs) == 0:
+                print('No objects in the world map.\n')
+                return
+            width = max([len(x[0]) for x in objs])
+            for obj in objs:
+                print(f'{obj[0].rjust(width)}: {obj[1]}')
+            print()
 
 
 
 ################ GPT interface ################
 
     def get_prompt(self):
-        prompt = ''
-        prompt += f'It is now {datetime.datetime.now().strftime("%B %d, %Y, %I:%M:%S %p")}.\n'
-        if self.robot.particle_filter.state == self.robot.particle_filter.LOCALIZED:
-            prompt += f'You are located at ({round(self.robot.pose.x)}, {round(self.robot.pose.y)})\n'
-            prompt += f'Your heading is {round(self.robot.pose.theta*180/pi)} degrees\n'
-        else:
-            prompt += f'You are currently lost (not localized) and do not see any landmarks.\n'
-        if self.robot.holding:
-            prompt += f'You are currently holding {self.robot.holding.id}.\n'
-        else:
-            prompt += f'You are not currently holding anything.\n'
-        prompt += f'Your battery level is {self.robot.battery_percentage} percent.\n'
-        for (id,obj) in self.objects.items():
-            if not obj.is_missing:
-                if obj.is_visible:
-                    vis = "visible"
-                else:
-                    vis = "not vislbie"
-                prompt += f'{id} is located at ({round(obj.pose.x)}, {round(obj.pose.y)}) ' + \
-                    f'and is {vis}\n'
+        with self._lock:
+            prompt = ''
+            prompt += f'It is now {datetime.datetime.now().strftime("%B %d, %Y, %I:%M:%S %p")}.\n'
+            if self.robot.particle_filter.state == self.robot.particle_filter.LOCALIZED:
+                prompt += f'You are located at ({round(self.robot.pose.x)}, {round(self.robot.pose.y)})\n'
+                prompt += f'Your heading is {round(self.robot.pose.theta*180/pi)} degrees\n'
             else:
-                prompt += f'{id} is missing\n'
+                prompt += f'You are currently lost (not localized) and do not see any landmarks.\n'
+            if self.robot.holding:
+                prompt += f'You are currently holding {self.robot.holding.id}.\n'
+            else:
+                prompt += f'You are not currently holding anything.\n'
+            prompt += f'Your battery level is {self.robot.battery_percentage} percent.\n'
+            for (id,obj) in self.objects.items():
+                if not obj.is_missing:
+                    if obj.is_visible:
+                        vis = "visible"
+                    else:
+                        vis = "not vislbie"
+                    prompt += f'{id} is located at ({round(obj.pose.x)}, {round(obj.pose.y)}) ' + \
+                        f'and is {vis}\n'
+                else:
+                    prompt += f'{id} is missing\n'
 
-            if isinstance(obj, WallObj):
-                front_markers = []
-                back_markers = []
-                for marker_id, marker_info in obj.wall_spec.marker_specs.items():
-                    if marker_info['side'] == 1:  # +1 means front side
-                        front_markers.append(marker_id)
-                    else:  # -1 means back side
-                        back_markers.append(marker_id)
-                prompt += f'{obj.id} has markers {front_markers} on its front side and {back_markers} on its back side\n'   
+                if isinstance(obj, WallObj):
+                    front_markers = []
+                    back_markers = []
+                    for marker_id, marker_info in obj.wall_spec.marker_specs.items():
+                        if marker_info['side'] == 1:  # +1 means front side
+                            front_markers.append(marker_id)
+                        else:  # -1 means back side
+                            back_markers.append(marker_id)
+                    prompt += f'{obj.id} has markers {front_markers} on its front side and {back_markers} on its back side\n'   
 
-            if isinstance(obj, DoorwayObj) and obj.wall:
-                prompt += f'{id} is part of {obj.wall.id}\n'
-        landmark_ids = list(self.robot.particle_filter.sensor_model.landmarks.keys())
-        if landmark_ids:
-            for id in landmark_ids:
-                prompt += f'{id} is a navigation landmark.'
-        else:
-            prompt += 'There are currently no navigation landmarks.'    
-        return prompt
+                if isinstance(obj, DoorwayObj) and obj.wall:
+                    prompt += f'{id} is part of {obj.wall.id}\n'
+            landmark_ids = list(self.robot.particle_filter.sensor_model.landmarks.keys())
+            if landmark_ids:
+                for id in landmark_ids:
+                    prompt += f'{id} is a navigation landmark.'
+            else:
+                prompt += 'There are currently no navigation landmarks.'    
+            return prompt

--- a/qml/ParticleView.qml
+++ b/qml/ParticleView.qml
@@ -179,7 +179,7 @@ FocusScope {
     function adjustCenter(dx, dy) {
         if (!root.viewStateRef || !root.viewStateRef.setCenter)
             return;
-        var scale = root.viewStateRef.zoom || 0.4;
+        var scale = root.viewStateRef.zoom || 1.0;
         var deltaX = dx / scale;
         var deltaY = dy / scale;
         root.viewStateRef.setCenter(root.viewStateRef.centerX + deltaY, root.viewStateRef.centerY - deltaX);

--- a/qml/WorldMapView.qml
+++ b/qml/WorldMapView.qml
@@ -480,7 +480,7 @@ View3D {
                         if (model.type === "apriltag")
                             return "#804ce6";
                         if (model.type === "aruco")
-                            return model.visible ? "#00ff00" : "#2a5c2a";
+                            return model.visible ? "#00ff00" : "#1f431f";
                         return "#202020";
                     }
                     emissiveFactor: {
@@ -499,9 +499,18 @@ View3D {
 
             // Hidden 2D Image to load texture from image provider
             Image {
-                id: tagImage
+                id: tagImageFront
                 source: (model.type === "apriltag" || model.type === "aruco")
                         ? "image://tagtexture/" + (model.type === "aruco" ? "aruco-" : "") + String(model.marker_id)
+                        : ""
+                visible: false
+                cache: true
+            }
+
+            Image {
+                id: tagImageBack
+                source: (model.type === "apriltag" || model.type === "aruco")
+                        ? "image://tagtexture/back-" + (model.type === "aruco" ? "aruco-" : "") + String(model.marker_id)
                         : ""
                 visible: false
                 cache: true
@@ -524,12 +533,13 @@ View3D {
                 materials: PrincipledMaterial {
                     baseColor: "#ffffff"
                     baseColorMap: Texture {
-                        sourceItem: tagImage
+                        sourceItem: tagImageFront
                     }
                     emissiveFactor: model.visible ? Qt.vector3d(0.1, 0.06, 0.2) : Qt.vector3d(0, 0, 0)
                     roughness: 0.1
                     cullMode: Material.NoCulling
                 }
+                opacity: model.visible ? 1.0 : 0.8
             }
             
             // Text label panel - Back face (-X direction)
@@ -549,12 +559,13 @@ View3D {
                 materials: PrincipledMaterial {
                     baseColor: "#ffffff"
                     baseColorMap: Texture {
-                        sourceItem: tagImage
+                        sourceItem: tagImageBack
                     }
                     emissiveFactor: model.visible ? Qt.vector3d(0.1, 0.06, 0.2) : Qt.vector3d(0, 0, 0)
                     roughness: 0.1
                     cullMode: Material.NoCulling
                 }
+                opacity: model.visible ? 1.0 : 0.8
             }
         }
     }
@@ -568,20 +579,92 @@ View3D {
             readonly property real lengthMm: model.length_mm || 300
             readonly property real heightMm: model.height_mm || 210
             readonly property real thicknessMm: model.thickness_mm || 4
+            readonly property var doorways: (model.doorways && model.doorways.length) ? model.doorways : []
+            readonly property real wallBaseLocalZ: -heightMm / 2
+            readonly property real doorHeightMm: {
+                if (!doorways.length)
+                    return 0
+                var maxHeight = 0
+                for (var i = 0; i < doorways.length; ++i) {
+                    var h = Number(doorways[i].height) || 0
+                    if (h > maxHeight)
+                        maxHeight = h
+                }
+                return Math.max(0, Math.min(heightMm, maxHeight))
+            }
+            readonly property real lowerHeightMm: doorHeightMm > 0 ? doorHeightMm : heightMm
+            readonly property var lowerSegments: computeLowerSegments()
             // Use model.z which is already computed in Python (height/2)
             position: Qt.vector3d(model.x, model.y, model.z)
             eulerRotation.z: radiansToDegrees(model.theta)
 
-            Model {
-                source: "#Cube"
-                // Qt Quick 3D #Cube: edge length=100
-                scale: Qt.vector3d(thicknessMm / 100, lengthMm / 100, heightMm / 100)
-                materials: PrincipledMaterial {
-                    baseColor: model.visible ? "#777777" : "#444444"
-                    roughness: 0.7
-                    cullMode: Material.NoCulling
-                    emissiveFactor: model.visible ? Qt.vector3d(0.05, 0.05, 0.05) : Qt.vector3d(0, 0, 0)
+            function computeLowerSegments() {
+                if (!doorways.length) {
+                    return [{ "center": 0, "width": lengthMm }]
                 }
+
+                var cursor = -lengthMm / 2
+                var end = lengthMm / 2
+                var segments = []
+                var sorted = []
+                for (var i = 0; i < doorways.length; ++i)
+                    sorted.push(doorways[i])
+                sorted.sort(function(a, b) { return Number(a.x) - Number(b.x) })
+
+                for (var j = 0; j < sorted.length; ++j) {
+                    var spec = sorted[j]
+                    var centerY = (Number(spec.x) || 0) - lengthMm / 2
+                    var width = Math.max(0, Number(spec.width) || 0)
+                    var left = centerY - width / 2
+                    var right = centerY + width / 2
+                    if (left > cursor) {
+                        var segWidth = left - cursor
+                        segments.push({
+                            "center": cursor + segWidth / 2,
+                            "width": segWidth
+                        })
+                    }
+                    cursor = Math.max(cursor, right)
+                }
+
+                if (cursor < end) {
+                    var tailWidth = end - cursor
+                    segments.push({
+                        "center": cursor + tailWidth / 2,
+                        "width": tailWidth
+                    })
+                }
+                return segments
+            }
+
+            PrincipledMaterial {
+                id: wallMaterial
+                baseColor: model.visible ? Qt.rgba(0.88, 0.78, 0.22, 0.74) : Qt.rgba(0.55, 0.48, 0.14, 0.60)
+                alphaMode: PrincipledMaterial.Blend
+                roughness: 0.65
+                cullMode: Material.NoCulling
+                emissiveFactor: model.visible ? Qt.vector3d(0.06, 0.06, 0.02) : Qt.vector3d(0.02, 0.02, 0.01)
+            }
+
+            Repeater3D {
+                model: lowerSegments.length
+                Model {
+                    property int idx: index
+                    source: "#Cube"
+                    property var seg: lowerSegments[idx]
+                    position: Qt.vector3d(0, Number(seg.center) || 0, wallBaseLocalZ + lowerHeightMm / 2)
+                    scale: Qt.vector3d(thicknessMm / 100, (Number(seg.width) || 0) / 100, lowerHeightMm / 100)
+                    materials: wallMaterial
+                }
+            }
+
+            Model {
+                visible: doorHeightMm > 0 && doorHeightMm < heightMm
+                source: "#Cube"
+                property real transomHeightMm: Math.max(0, heightMm - doorHeightMm)
+                position: Qt.vector3d(0, 0, wallBaseLocalZ + doorHeightMm + transomHeightMm / 2)
+                scale: Qt.vector3d(thicknessMm / 100, lengthMm / 100, transomHeightMm / 100)
+                materials: wallMaterial
             }
         }
     }

--- a/qml/layers/ParticleCanvas.qml
+++ b/qml/layers/ParticleCanvas.qml
@@ -40,7 +40,7 @@ Canvas {
 
     function pixelsPerMm() {
         if (!viewState || viewState.zoom === undefined || viewState.zoom === null)
-            return 0.4;
+            return 1.0;
         return Math.max(0.01, viewState.zoom);
     }
 
@@ -152,6 +152,67 @@ Canvas {
         ctx.restore();
     }
 
+    function drawHeadingWedge(ctx) {
+        if (!particleSummary || !particleSummary.isValid)
+            return;
+        var scale = pixelsPerMm();
+        var center = mapPoint(particleSummary.poseX, particleSummary.poseY);
+        var thetaVar = Math.max(0, Number(particleSummary.thetaVariance) || 0);
+        var spanDeg = Math.max(5, Math.sqrt(thetaVar) * 360.0);
+        var halfSpan = (spanDeg * Math.PI / 180.0) * 0.5;
+        var radius = 75 * scale;
+        ctx.save();
+        ctx.translate(center.x, center.y);
+        ctx.rotate(-(particleSummary.poseTheta + Math.PI / 2));
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.arc(0, 0, radius, -halfSpan, halfSpan, false);
+        ctx.closePath();
+        ctx.fillStyle = "rgba(60, 180, 255, 0.24)";
+        ctx.fill();
+        ctx.strokeStyle = "rgba(110, 210, 255, 0.65)";
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+        ctx.restore();
+    }
+
+    function drawLandmarkEllipse(ctx, entry, scale) {
+        var sxx = Number(entry.sigma_xx) || 0;
+        var sxy = Number(entry.sigma_xy) || 0;
+        var syy = Number(entry.sigma_yy) || 0;
+        if (sxx <= 0 && syy <= 0 && Math.abs(sxy) < 1e-6)
+            return;
+
+        var trace = sxx + syy;
+        var det = sxx * syy - sxy * sxy;
+        var radicand = Math.max(0, trace * trace * 0.25 - det);
+        var term = Math.sqrt(radicand);
+        var eig1 = Math.max(0, trace * 0.5 + term);
+        var eig2 = Math.max(0, trace * 0.5 - term);
+        if (eig1 <= 0 && eig2 <= 0)
+            return;
+
+        var major = Math.sqrt(Math.max(eig1, eig2)) * scale;
+        var minor = Math.sqrt(Math.min(eig1, eig2)) * scale;
+        if (major < 1 || minor < 1)
+            return;
+        var angle = 0.5 * Math.atan2(2 * sxy, sxx - syy);
+        var center = mapPoint(entry.x, entry.y);
+
+        ctx.save();
+        ctx.translate(center.x, center.y);
+        ctx.rotate(-(angle + Math.PI / 2));
+        ctx.beginPath();
+        ctx.ellipse(0, 0, major, minor, 0, 0, Math.PI * 2);
+        if (entry.kind === "wall")
+            ctx.strokeStyle = "rgba(170, 150, 255, 0.85)";
+        else
+            ctx.strokeStyle = "rgba(255, 150, 200, 0.85)";
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+        ctx.restore();
+    }
+
     function drawRobot(ctx) {
         // Draw the robot as a large yellow triangle at the best pose estimate
         // Legacy: height=60mm, tip_offset=-10mm, color=(1,1,0,0.7)
@@ -194,11 +255,20 @@ Canvas {
             ctx.translate(pos.x, pos.y);
             ctx.rotate(-(entry.theta + Math.PI / 2));
             if (entry.kind === "wall") {
-                var halfLength = (entry.length_mm || 100) * 0.5 * scale;
-                var halfWidth = Math.max(10 * scale, (entry.width_mm || 50) * 0.5 * scale);
-                ctx.strokeStyle = entry.seen ? "rgba(255, 140, 90, 0.9)" : "rgba(120, 80, 60, 0.5)";
-                ctx.lineWidth = 2;
-                ctx.strokeRect(-halfLength, -halfWidth / 4, halfLength * 2, halfWidth / 2);
+                var wallLength = Math.max(20, Number(entry.length_mm) || 100) * scale;
+                var wallThickness = Math.max(3, 20 * scale);
+                ctx.strokeStyle = entry.seen ? "rgba(255, 170, 90, 0.98)" : "rgba(175, 120, 60, 0.9)";
+                ctx.lineWidth = Math.max(2.5, 2.0 * scale);
+                ctx.strokeRect(-wallThickness / 2, -wallLength / 2, wallThickness, wallLength);
+
+                ctx.save();
+                ctx.rotate(entry.theta + Math.PI / 2);
+                ctx.fillStyle = entry.seen ? "rgba(255, 226, 160, 0.98)" : "rgba(215, 186, 132, 0.85)";
+                ctx.font = Math.max(10, 13 * scale) + "px sans-serif";
+                ctx.textAlign = "center";
+                ctx.textBaseline = "middle";
+                ctx.fillText(String(entry.label || entry.id), 0, -wallLength * 0.56);
+                ctx.restore();
             } else {
                 var size = 20 * scale;
                 ctx.strokeStyle = entry.seen ? "rgba(130, 255, 120, 0.9)" : "rgba(90, 150, 90, 0.6)";
@@ -216,6 +286,7 @@ Canvas {
                 }
             }
             ctx.restore();
+            drawLandmarkEllipse(ctx, entry, scale);
         }
     }
 
@@ -226,9 +297,10 @@ Canvas {
         ctx.fillRect(0, 0, width, height);
 
         drawGrid(ctx);
+        drawParticles(ctx);
+        drawSummary(ctx);
+        drawHeadingWedge(ctx);
+        drawRobot(ctx);
         drawLandmarks(ctx);
-        drawParticles(ctx);    // Draw particles first (red, small)
-        drawSummary(ctx);      // Draw error ellipse (cyan)
-        drawRobot(ctx);        // Draw robot on top (yellow, large)
     }
 }

--- a/viewer/particle_model.py
+++ b/viewer/particle_model.py
@@ -386,7 +386,19 @@ class LandmarkModel(QAbstractListModel):
             pf_landmarks = {}
 
         world_objects_by_string = {}
-        for obj in world_map.objects.values():
+        if world_map is not None:
+            snapshot = getattr(world_map, "snapshot_objects", None)
+            try:
+                if callable(snapshot):
+                    world_objects = snapshot() or {}
+                else:
+                    world_objects = dict(getattr(world_map, "objects", {}) or {})
+            except Exception:
+                world_objects = {}
+        else:
+            world_objects = {}
+
+        for obj in world_objects.values():
             if isinstance(obj, ArucoMarkerObj):
                 world_objects_by_string[obj.marker_string] = obj
             else:

--- a/viewer/particle_model.py
+++ b/viewer/particle_model.py
@@ -52,10 +52,16 @@ def _flatten_vector(value: Any) -> Sequence[float]:
 
 def _covariance_components(matrix: Any) -> tuple[float, float, float]:
     try:
-        arr = np.asarray(matrix, dtype=float).reshape(2, 2)
-        return float(arr[0, 0]), float(arr[0, 1]), float(arr[1, 1])
+        arr = np.asarray(matrix, dtype=float)
+        if arr.ndim == 2 and arr.shape[0] >= 2 and arr.shape[1] >= 2:
+            return float(arr[0, 0]), float(arr[0, 1]), float(arr[1, 1])
+        flat = arr.reshape(-1)
+        if flat.size >= 4:
+            mat = flat[:4].reshape(2, 2)
+            return float(mat[0, 0]), float(mat[0, 1]), float(mat[1, 1])
     except Exception:
-        return 0.0, 0.0, 0.0
+        pass
+    return 0.0, 0.0, 0.0
 
 
 def _ellipse_axes(matrix: Any) -> tuple[float, float, float]:
@@ -123,7 +129,7 @@ def _label_from(name: str, world_obj: Any) -> str:
     if name.startswith("ArucoMarker-"):
         return name.split("-", 1)[-1]
     if name.startswith("Wall-"):
-        return "W" + name.split("-", 1)[-1]
+        return name
     return name
 
 
@@ -401,8 +407,12 @@ class LandmarkModel(QAbstractListModel):
         for obj in world_objects.values():
             if isinstance(obj, ArucoMarkerObj):
                 world_objects_by_string[obj.marker_string] = obj
-            else:
-                world_objects_by_string[obj.name] = obj
+            obj_name = getattr(obj, "name", None)
+            if isinstance(obj_name, str) and obj_name:
+                world_objects_by_string[obj_name] = obj
+            obj_id = getattr(obj, "id", None)
+            if isinstance(obj_id, str) and obj_id:
+                world_objects_by_string[obj_id] = obj
                 
         if hasattr(pf_landmarks, "items"):
             lm_iterable = pf_landmarks.items()
@@ -464,6 +474,10 @@ class LandmarkModel(QAbstractListModel):
             sigma_xx, sigma_xy, sigma_yy = _covariance_components(sigma)
         else:
             x, y, theta = _pose_components(spec)
+
+        if marker_id is None and name.startswith("ArucoMarker-"):
+            marker_token = name.split("-", 1)[-1]
+            marker_id = marker_token.split(".", 1)[0]
 
         entry: Item = {
             "id": name,

--- a/viewer/particle_viewer.py
+++ b/viewer/particle_viewer.py
@@ -29,7 +29,7 @@ class ParticleViewState(QObject):
         self,
         center_x: float = 0.0,
         center_y: float = 0.0,
-        zoom: float = 0.4,
+        zoom: float = 1.0,
         parent: Optional[QObject] = None,
     ) -> None:
         super().__init__(parent)
@@ -77,7 +77,7 @@ class ParticleViewer(QObject):
         robot: Any,
         width: int = 640,
         height: int = 640,
-        scale: float = 0.64,  # legacy compatibility (unused)
+        scale: float = 0.64,  # legacy compatibility; now used as initial zoom hint
         windowName: str = "Particle Viewer",
         bgcolor: tuple[float, float, float] | tuple[int, int, int] = (0, 0, 0),  # legacy compatibility
         update_interval_ms: int = 50,
@@ -96,7 +96,10 @@ class ParticleViewer(QObject):
         self._particle_model = ParticleLayerModel()
         self._landmark_model = LandmarkModel()
         self._summary = ParticleSummary()
-        self._view_state = ParticleViewState()
+        initial_zoom = float(scale)
+        if math.isclose(initial_zoom, 0.64, rel_tol=0.0, abs_tol=1e-9):
+            initial_zoom = 1.0
+        self._view_state = ParticleViewState(zoom=initial_zoom)
         self._auto_center = False
         self._verbose = False
         self._update_interval_ms = max(0, int(update_interval_ms))

--- a/viewer/qt_app.py
+++ b/viewer/qt_app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Any, Optional
 
@@ -51,6 +52,7 @@ class QtViewerApp(QObject):
         self._snapshot_service = snapshot_service or SnapshotService()
         self._snapshot_service.enable_disk_write(snapshots_enabled)
         self._camera_provider.set_robot_ref(self._robot)
+        self._last_refresh_error_ts = 0.0
 
         self._frame_counter = 0
         self._timer = QTimer(self)
@@ -82,14 +84,15 @@ class QtViewerApp(QObject):
         return self._view
 
     def refresh(self) -> None:
+        snapshot = getattr(self._worldmap, "snapshot_objects", None)
         try:
-            update = getattr(self._worldmap, "update", None)
-            if callable(update):
-                update()
-        except Exception:
-            # Debug output belongs to the caller; swallow to keep viewer resilient.
-            pass
-        objects = getattr(self._worldmap, "objects", {}) or {}
+            if callable(snapshot):
+                objects = snapshot() or {}
+            else:
+                objects = dict(getattr(self._worldmap, "objects", {}) or {})
+        except Exception as exc:
+            self._log_refresh_error(exc)
+            objects = {}
         self._model.sync_from(self._robot, objects)
 
     def start(self) -> None:
@@ -184,6 +187,12 @@ class QtViewerApp(QObject):
 
         print(f"[QtViewerApp] Snapshot saved to {path}")
         return str(path)
+
+    def _log_refresh_error(self, exc: Exception) -> None:
+        now = time.monotonic()
+        if now - self._last_refresh_error_ts >= 1.0:
+            print(f"[QtViewerApp] refresh failed: {exc}")
+            self._last_refresh_error_ts = now
 
 
 __all__ = ["QtViewerApp"]

--- a/viewer/worldmap_model.py
+++ b/viewer/worldmap_model.py
@@ -76,9 +76,11 @@ class WorldMapModel(QAbstractListModel):
         "diameter_mm",
         "height_mm",
         "length_mm",
+        "width_mm",
         "thickness_mm",
         "size_mm",
         "marker_id",
+        "doorways",
         "holding",
     )
 
@@ -166,9 +168,11 @@ class WorldMapModel(QAbstractListModel):
             "diameter_mm": 64.0,
             "height_mm": 72.0,
             "length_mm": None,
+            "width_mm": None,
             "thickness_mm": None,
             "size_mm": None,
             "marker_id": None,
+            "doorways": [],
             "holding": bool(getattr(robot, "holding", False)),
         }
         return entry
@@ -197,9 +201,11 @@ class WorldMapModel(QAbstractListModel):
             "diameter_mm": None,
             "height_mm": None,
             "length_mm": None,
+            "width_mm": None,
             "thickness_mm": None,
             "size_mm": None,
             "marker_id": None,
+            "doorways": [],
             "holding": None,
         }
 
@@ -250,6 +256,23 @@ class WorldMapModel(QAbstractListModel):
             entry["height_mm"] = height
             entry["thickness_mm"] = 4.0
             entry["z"] = height / 2.0 if height else entry["z"]
+            wall_spec = getattr(obj, "wall_spec", None)
+            door_specs = getattr(wall_spec, "doorways", None)
+            doorways: list[Item] = []
+            if isinstance(door_specs, Mapping):
+                sorted_specs = sorted(door_specs.items(), key=lambda pair: int(pair[0]))
+                for index, spec in sorted_specs:
+                    if not isinstance(spec, Mapping):
+                        continue
+                    doorways.append(
+                        {
+                            "index": int(index),
+                            "x": _to_float(spec.get("x"), 0.0),
+                            "width": max(0.0, _to_float(spec.get("width"), 0.0)),
+                            "height": max(0.0, _to_float(spec.get("height"), 0.0)),
+                        }
+                    )
+            entry["doorways"] = doorways
 
         return entry
 

--- a/viewer/worldmap_viewer.py
+++ b/viewer/worldmap_viewer.py
@@ -39,22 +39,29 @@ class TagTextureProvider(QQuickImageProvider):
             Tuple of (QImage, QSize)
         """
         result_size = QSize(self._texture_width, self._texture_height)
+        cache_key = id or ""
 
-        if not id or id == "null" or id == "None":
+        if not cache_key or cache_key == "null" or cache_key == "None":
             # Return transparent image for missing IDs
             img = QImage(self._texture_width, self._texture_height, QImage.Format.Format_RGBA8888)
             img.fill(QColor(0, 0, 0, 0))
             return img, result_size
 
         # Check cache
-        if id in self._cache:
-            return self._cache[id], result_size
+        if cache_key in self._cache:
+            return self._cache[cache_key], result_size
 
-        label = id
+        texture_id = cache_key
+        reverse_text = False
+        if texture_id.startswith("back-"):
+            reverse_text = True
+            texture_id = texture_id[len("back-") :]
+
+        label = texture_id
         background = QColor(128, 76, 230, 255)  # Purple background matching AprilTag color
         text_color = QColor(255, 255, 255, 255)
-        if id.startswith("aruco-"):
-            label = id.split("-", 1)[1]
+        if texture_id.startswith("aruco-"):
+            label = texture_id.split("-", 1)[1]
             background = QColor(0, 255, 0, 255)  # Bright green for ArUco
             text_color = QColor(0, 0, 0, 255)
 
@@ -77,8 +84,11 @@ class TagTextureProvider(QQuickImageProvider):
 
         painter.end()
 
+        if reverse_text:
+            img = img.mirrored(True, False)
+
         # Cache the result
-        self._cache[id] = img
+        self._cache[cache_key] = img
         return img, result_size
 
 

--- a/viewer/worldmap_viewer.py
+++ b/viewer/worldmap_viewer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import time
 from pathlib import Path
 from typing import Any, Optional
 
@@ -107,6 +108,7 @@ class WorldMapViewer(QObject):
         self._width = int(width)
         self._height = int(height)
         self._window_name = windowName
+        self._last_refresh_error_ts = 0.0
 
         self._app = QGuiApplication.instance() or QGuiApplication([])
         self._model = WorldMapModel()
@@ -141,15 +143,15 @@ class WorldMapViewer(QObject):
         self._view.close()
 
     def refresh(self) -> None:
+        snapshot = getattr(self._worldmap, "snapshot_objects", None)
         try:
-            update = getattr(self._worldmap, "update", None)
-            if callable(update):
-                update()
-        except Exception:
-            pass
-
-        # Always use worldmap.objects (shared_map is Cozmo holdover code, not implemented for VEX AIM)
-        objects = getattr(self._worldmap, "objects", {}) or {}
+            if callable(snapshot):
+                objects = snapshot() or {}
+            else:
+                objects = dict(getattr(self._worldmap, "objects", {}) or {})
+        except Exception as exc:
+            self._log_refresh_error(exc)
+            objects = {}
         self._model.sync_from(self._robot, objects)
 
     def grab_window(self) -> QImage:
@@ -212,6 +214,12 @@ class WorldMapViewer(QObject):
             return
         if root is not None and hasattr(root, "forceActiveFocus"):
             root.forceActiveFocus()
+
+    def _log_refresh_error(self, exc: Exception) -> None:
+        now = time.monotonic()
+        if now - self._last_refresh_error_ts >= 1.0:
+            print(f"[WorldMapViewer] refresh failed: {exc}")
+            self._last_refresh_error_ts = now
 
 
 __all__ = ["WorldMapViewer"]


### PR DESCRIPTION
## Bug Fixes (worldmap.py)
- Fix wall inference crash: `infer_wall_from_corners_lists` now returns `None` instead of crashing when all markers fail solvePnP
- Fix `reclaim_object` not clearing `is_missing` flag, causing objects to be hidden in QML viewer despite being in the world map
- Add AprilTag `tag_id` check in association/reclaim to prevent cross-ID mismatches
- Add RLock + `snapshot_objects()` for thread-safe viewer reads
- Viewer refresh no longer calls `world_map.update()`; reads snapshot only
- ArUco detection results built locally before publishing to avoid partial-update reads

## Viewer Improvements
- ArUco markers: front/back face distinction, darker when unobserved
- Particle viewer: ArUco landmark IDs shown in green box
- Walls: yellow semi-transparent + doorway cutouts
- Particle viewer: fixed 90° wall orientation offset, added wall labels
- Restored landmark uncertainty ellipses and robot heading uncertainty wedge
- Adjusted default zoom for better close-range readability