### PR TITLE
Fix viewer relaunch and imshow window behavior

### DIFF
--- a/aim_fsm/program.py
+++ b/aim_fsm/program.py
@@ -28,6 +28,7 @@ from viewer.particle_viewer import ParticleViewer
 from .rrt import RRT
 from viewer.path_viewer import PathViewer
 from viewer.camera_overlay import apply_overlays
+from viewer.lifecycle import ensure_viewer
 from .camera import AIVISION_RESOLUTION_SCALE
 from . import pilot
 #from . import custom_objs
@@ -148,26 +149,32 @@ class StateMachineProgram(StateNode):
 
         # Launch viewers
         if self.launch_cam_viewer:
-            if not self.robot.cam_viewer:
-                self.robot.cam_viewer = \
-                    CamViewer(self.robot, user_annotate_function=self.user_annotate)
-                self.robot.cam_viewer.start()
+            ensure_viewer(
+                self.robot,
+                'cam_viewer',
+                lambda: CamViewer(self.robot, user_annotate_function=self.user_annotate),
+            )
 
         if self.launch_worldmap_viewer:
-            if not self.robot.worldmap_viewer is True:
-                self.robot.worldmap_viewer = WorldMapViewer(self.robot)
-                self.robot.worldmap_viewer.start()
+            ensure_viewer(
+                self.robot,
+                'worldmap_viewer',
+                lambda: WorldMapViewer(self.robot),
+            )
 
         if self.launch_particle_viewer:
-            if not self.robot.particle_viewer:
-                self.robot.particle_viewer = \
-                    ParticleViewer(self.robot, scale=self.particle_viewer_scale)
-                self.robot.particle_viewer.start()
+            ensure_viewer(
+                self.robot,
+                'particle_viewer',
+                lambda: ParticleViewer(self.robot, scale=self.particle_viewer_scale),
+            )
 
         if self.launch_path_viewer:
-            if not self.robot.path_viewer:
-                self.robot.path_viewer = PathViewer(self.robot, self.robot.rrt)
-            self.robot.path_viewer.start()
+            ensure_viewer(
+                self.robot,
+                'path_viewer',
+                lambda: PathViewer(self.robot, self.robot.rrt),
+            )
 
         if self.speech:
             self.robot.speech_listener.enable()

--- a/simple_cli
+++ b/simple_cli
@@ -42,6 +42,7 @@ except:
 import aim_fsm
 from aim_fsm import *
 from aim_fsm.program import runfsm as _program_runfsm
+from viewer.lifecycle import ensure_viewer as _ensure_viewer_for_target
 
 try:
     from viewer.imshow_manager import imshow_pump
@@ -111,18 +112,7 @@ def runfsm(module_name):
 
 def _ensure_viewer(attr, factory):
     target = globals().get('robot')
-    if target is None:
-        return None
-
-    viewer = getattr(target, attr, None)
-    if viewer and viewer is not True:
-        return viewer
-
-    viewer = factory()
-    if hasattr(viewer, 'start'):
-        viewer.start()
-    setattr(target, attr, viewer)
-    return viewer
+    return _ensure_viewer_for_target(target, attr, factory)
 
 
 def _prime_default_viewers(program, launch_overrides=None):
@@ -135,16 +125,16 @@ def _prime_default_viewers(program, launch_overrides=None):
 
     flags = launch_overrides or {}
     if flags.get('cam', getattr(program, 'launch_cam_viewer', False)):
-        _ensure_viewer('cam_viewer', lambda: CamViewer(target_robot))
+        _ensure_viewer_for_target(target_robot, 'cam_viewer', lambda: CamViewer(target_robot))
 
     if flags.get('worldmap', getattr(program, 'launch_worldmap_viewer', False)):
-        _ensure_viewer('worldmap_viewer', lambda: WorldMapViewer(target_robot))
+        _ensure_viewer_for_target(target_robot, 'worldmap_viewer', lambda: WorldMapViewer(target_robot))
 
     if flags.get('particle', getattr(program, 'launch_particle_viewer', False)):
-        _ensure_viewer('particle_viewer', lambda: ParticleViewer(target_robot))
+        _ensure_viewer_for_target(target_robot, 'particle_viewer', lambda: ParticleViewer(target_robot))
 
     if flags.get('path', getattr(program, 'launch_path_viewer', False)):
-        _ensure_viewer('path_viewer', lambda: PathViewer(target_robot))
+        _ensure_viewer_for_target(target_robot, 'path_viewer', lambda: PathViewer(target_robot))
 
 
 _pending_viewer_launches = SimpleQueue()
@@ -194,7 +184,7 @@ def _drain_pending_viewer_launches_once():
         _prime_default_viewers(program, launch_flags)
         processed = True
     if imshow_pump is not None:
-        imshow_pump()
+        processed = imshow_pump() or processed
     return processed
 
 
@@ -225,6 +215,12 @@ def _process_qt_events_if_needed():
     app = QGuiApplication.instance()
     if app:
         app.processEvents()
+
+
+def _flush_main_thread_gui(timeout=0.15):
+    _process_qt_events_if_needed()
+    _process_pending_viewer_launches(timeout=timeout)
+    _process_qt_events_if_needed()
 
 def cli_loop(_robot):
     global ans, RUNNING, robot, file_to_run, running_fsm
@@ -275,12 +271,14 @@ def cli_loop(_robot):
             continue
         elif cli_loop._line[0:2] == '. ':
             do_hear_command(cli_loop._line[2:])
+            _flush_main_thread_gui()
             continue
         elif cli_loop._line[0:2] == '.?':
             show_messages(cli_loop._line)
             continue
         elif cli_loop._line[0:3] == 'tm ' or cli_loop._line == 'tm':
             text_message(cli_loop._line[3:])
+            _flush_main_thread_gui()
             continue
         elif cli_loop._line[0:5] == 'show ' or cli_loop._line == 'show':
             show_args = cli_loop._line[5:].split(' ')
@@ -396,7 +394,9 @@ def show_stuff(args):
             running_fsm.cam_viewer = True
         _ensure_viewer('cam_viewer', lambda: CamViewer(robot))
     elif spec == "crosshairs":
-        robot.cam_viewer.crosshairs = not robot.cam_viewer.crosshairs
+        viewer = _ensure_viewer('cam_viewer', lambda: CamViewer(robot))
+        if viewer is not None:
+            viewer.crosshairs = not viewer.crosshairs
     elif spec == "particle_viewer":
         _ensure_viewer('particle_viewer', lambda: ParticleViewer(robot))
     elif spec == "path_viewer":

--- a/viewer/cam_viewer.py
+++ b/viewer/cam_viewer.py
@@ -13,6 +13,7 @@ from aim_fsm.camera import AIVISION_RESOLUTION_SCALE
 
 from .camera_provider import CameraImageProvider
 from .help_texts import CAMERA_HELP_TEXT
+from .lifecycle import stop_timer_if_view_hidden
 from .snapshot_service import SnapshotService
 
 
@@ -62,6 +63,7 @@ class CamViewer(QObject):
         self._view = QQuickView()
         self._view.setResizeMode(QQuickView.ResizeMode.SizeRootObjectToView)
         self._view.setTitle(self._window_title)
+        self._bind_visibility_handler()
 
         self._context = self._initialise_qml_context()
         self._sync_crosshair_to_qml()
@@ -77,6 +79,7 @@ class CamViewer(QObject):
         self._view.setWidth(self._width)
         self._view.setHeight(self._height)
         self._view.show()
+        self._focus_root()
         self._sync_crosshair_to_qml()
 
     def stop(self) -> None:
@@ -85,6 +88,9 @@ class CamViewer(QObject):
 
     def is_running(self) -> bool:
         return self._timer.isActive()
+
+    def is_visible(self) -> bool:
+        return self._view.isVisible()
 
     def capture_raw(self, name: str = "robot_snap") -> Optional[str]:
         """Persist the latest raw frame using the snapshot service."""
@@ -153,6 +159,24 @@ class CamViewer(QObject):
 
         self._view.setSource(QUrl.fromLocalFile(str(qml_path)))
         return context
+
+    def _bind_visibility_handler(self) -> None:
+        signal = getattr(self._view, "visibleChanged", None)
+        if signal is None:
+            signal = getattr(self._view, "visibilityChanged", None)
+        if signal is not None:
+            signal.connect(self._handle_visibility_changed)
+
+    def _handle_visibility_changed(self, *args) -> None:
+        stop_timer_if_view_hidden(self._view, self._timer)
+
+    def _focus_root(self) -> None:
+        try:
+            root = self._view.rootObject()
+        except Exception:
+            return
+        if root is not None and hasattr(root, "forceActiveFocus"):
+            root.forceActiveFocus()
 
     def _poll_robot(self) -> None:
         image = getattr(self._robot, "camera_image", None)

--- a/viewer/imshow_manager.py
+++ b/viewer/imshow_manager.py
@@ -91,7 +91,7 @@ class WindowManager:
         """
         if not self._on_main_thread():
             window = self.get_window(window_name)
-            if window is not None:
+            if window is not None and window.is_visible():
                 window.display(image)
                 return
             with self._pending_lock:
@@ -101,11 +101,11 @@ class WindowManager:
         self._imshow_main_thread(window_name, image)
         self._process_events()
 
-    def process_pending(self, process_events: bool = True) -> None:
+    def process_pending(self, process_events: bool = True) -> bool:
         if not self._on_main_thread():
-            return
+            return False
         if self._processing:
-            return
+            return False
         self._processing = True
         try:
             pending_ops = []
@@ -130,29 +130,26 @@ class WindowManager:
             for window_name, image in pending_images.items():
                 self._imshow_main_thread(window_name, image)
 
-            if process_events and (pending_ops or pending_images):
+            processed = bool(pending_ops or pending_images)
+            if process_events and processed:
                 self._process_events()
+            return processed
         finally:
             self._processing = False
 
     def _imshow_main_thread(self, window_name: str, image: np.ndarray) -> None:
-        # Check if window exists but was closed by user
         window = self.get_window(window_name)
-        if window is not None and not window.is_visible():
-            # Window was manually closed, remove and recreate
-            # This matches cv2 behavior where closing and re-imshow() works
-            self._destroy_window_main_thread(window_name)
-            window = None
-
-        # Create window if it doesn't exist
         if window is None:
             window = self.create_window(window_name)
+        if not window.is_visible():
             window.show()
 
         window.display(image)
 
     def _named_window_main_thread(self, window_name: str) -> None:
-        self.create_window(window_name)
+        window = self.create_window(window_name)
+        if not window.is_visible():
+            window.show()
 
     def _destroy_window_main_thread(self, window_name: str) -> None:
         with self._lock:
@@ -196,7 +193,8 @@ def namedWindow(window_name: str, flags: int = 0) -> None:
         flags: Ignored (for cv2 compatibility)
     """
     if _manager._on_main_thread():
-        _manager.create_window(window_name)
+        _manager._named_window_main_thread(window_name)
+        _manager._process_events()
     else:
         _manager._pending_ops.put(("namedWindow", window_name))
 
@@ -225,9 +223,9 @@ def destroyAllWindows() -> None:
     _manager.destroy_all_windows()
 
 
-def imshow_pump() -> None:
+def imshow_pump() -> bool:
     """Process queued imshow window operations on the main thread."""
-    _manager.process_pending()
+    return _manager.process_pending()
 
 
 __all__ = [

--- a/viewer/lifecycle.py
+++ b/viewer/lifecycle.py
@@ -1,0 +1,68 @@
+"""Shared viewer lifecycle helpers used by the CLI and program startup."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def viewer_is_visible(viewer: Any) -> bool:
+    """Return True when the viewer exists and its window is currently visible."""
+
+    if viewer is None or viewer is True:
+        return False
+
+    probe = getattr(viewer, "is_visible", None)
+    if callable(probe):
+        try:
+            return bool(probe())
+        except Exception:
+            return False
+
+    return False
+
+
+def ensure_viewer(target: Any, attr: str, factory: Callable[[], Any]) -> Any:
+    """Create or relaunch a viewer stored on ``target``."""
+
+    if target is None:
+        return None
+
+    viewer = getattr(target, attr, None)
+    if viewer is not None and viewer is not True:
+        if viewer_is_visible(viewer):
+            return viewer
+
+        start = getattr(viewer, "start", None)
+        if callable(start):
+            start()
+        return viewer
+
+    viewer = factory()
+    start = getattr(viewer, "start", None)
+    if callable(start):
+        start()
+    setattr(target, attr, viewer)
+    return viewer
+
+def stop_timer_if_view_hidden(view: Any, timer: Any) -> None:
+    """Stop ``timer`` when ``view`` is hidden, ignoring Qt teardown races."""
+
+    try:
+        visible = bool(view.isVisible())
+    except RuntimeError:
+        return
+    except Exception:
+        return
+
+    if visible:
+        return
+
+    try:
+        timer.stop()
+    except RuntimeError:
+        return
+    except Exception:
+        return
+
+
+__all__ = ["ensure_viewer", "viewer_is_visible", "stop_timer_if_view_hidden"]

--- a/viewer/particle_viewer.py
+++ b/viewer/particle_viewer.py
@@ -17,6 +17,7 @@ except ImportError:  # pragma: no cover - optional during standalone tools
     AIVISION_RESOLUTION_SCALE = 1.0
 
 from .help_texts import PARTICLE_HELP_TEXT
+from .lifecycle import stop_timer_if_view_hidden
 from .particle_model import LandmarkModel, ParticleLayerModel, ParticleSummary
 
 
@@ -112,6 +113,7 @@ class ParticleViewer(QObject):
         self._view = QQuickView()
         self._view.setTitle(self._window_name)
         self._view.setResizeMode(QQuickView.ResizeMode.SizeRootObjectToView)
+        self._bind_visibility_handler()
 
         self._context = self._initialise_qml_context()
         self.refresh()
@@ -131,6 +133,9 @@ class ParticleViewer(QObject):
     def stop(self) -> None:
         self._timer.stop()
         self._view.close()
+
+    def is_visible(self) -> bool:
+        return self._view.isVisible()
 
     def refresh(self) -> None:
         particle_filter = getattr(self._robot, "particle_filter", None)
@@ -368,6 +373,16 @@ class ParticleViewer(QObject):
             errors = "\n".join(error.toString() for error in self._view.errors())
             raise RuntimeError(f"Failed to load ParticleView.qml:\n{errors}")
         return context
+
+    def _bind_visibility_handler(self) -> None:
+        signal = getattr(self._view, "visibleChanged", None)
+        if signal is None:
+            signal = getattr(self._view, "visibilityChanged", None)
+        if signal is not None:
+            signal.connect(self._handle_visibility_changed)
+
+    def _handle_visibility_changed(self, *args) -> None:
+        stop_timer_if_view_hidden(self._view, self._timer)
 
     def _focus_root(self) -> None:
         try:

--- a/viewer/path_viewer.py
+++ b/viewer/path_viewer.py
@@ -13,6 +13,7 @@ from PyQt6.QtQuick import QQuickView
 from aim_fsm.rrt import RRT
 
 from .help_texts import PATH_HELP_TEXT
+from .lifecycle import stop_timer_if_view_hidden
 from .path_model import (
     CircleItem,
     PathNodeModel,
@@ -125,6 +126,7 @@ class PathViewer(QObject):
         self._view = QQuickView()
         self._view.setTitle(self._window_name)
         self._view.setResizeMode(QQuickView.ResizeMode.SizeRootObjectToView)
+        self._bind_visibility_handler()
 
         self._context = self._initialise_qml_context()
         self.refresh()
@@ -175,6 +177,9 @@ class PathViewer(QObject):
     def stop(self) -> None:
         self._timer.stop()
         self._view.close()
+
+    def is_visible(self) -> bool:
+        return self._view.isVisible()
 
     def clear(self) -> None:
         self._scene_provider.clear_extra_trees()
@@ -325,6 +330,16 @@ class PathViewer(QObject):
             errors = "\n".join(error.toString() for error in self._view.errors())
             raise RuntimeError(f"Failed to load PathViewer.qml:\n{errors}")
         return context
+
+    def _bind_visibility_handler(self) -> None:
+        signal = getattr(self._view, "visibleChanged", None)
+        if signal is None:
+            signal = getattr(self._view, "visibilityChanged", None)
+        if signal is not None:
+            signal.connect(self._handle_visibility_changed)
+
+    def _handle_visibility_changed(self, *args) -> None:
+        stop_timer_if_view_hidden(self._view, self._timer)
 
     def _focus_root(self) -> None:
         try:

--- a/viewer/worldmap_viewer.py
+++ b/viewer/worldmap_viewer.py
@@ -14,6 +14,7 @@ from PyQt6.QtQuick import QQuickImageProvider, QQuickView
 from aim_fsm.camera import AIVISION_RESOLUTION_SCALE  # legacy code expects this in scope
 
 from .help_texts import WORLD_HELP_TEXT
+from .lifecycle import stop_timer_if_view_hidden
 from .worldmap_model import WorldMapModel
 
 
@@ -131,6 +132,7 @@ class WorldMapViewer(QObject):
         self._view = QQuickView()
         self._view.setTitle(self._window_name)
         self._view.setResizeMode(QQuickView.ResizeMode.SizeRootObjectToView)
+        self._bind_visibility_handler()
 
         self._context = self._initialise_qml_context()
         self.refresh()
@@ -151,6 +153,9 @@ class WorldMapViewer(QObject):
     def stop(self) -> None:
         self._timer.stop()
         self._view.close()
+
+    def is_visible(self) -> bool:
+        return self._view.isVisible()
 
     def refresh(self) -> None:
         snapshot = getattr(self._worldmap, "snapshot_objects", None)
@@ -216,6 +221,16 @@ class WorldMapViewer(QObject):
             errors = "\n".join(error.toString() for error in self._view.errors())
             raise RuntimeError(f"Failed to load WorldMapView.qml:\n{errors}")
         return context
+
+    def _bind_visibility_handler(self) -> None:
+        signal = getattr(self._view, "visibleChanged", None)
+        if signal is None:
+            signal = getattr(self._view, "visibilityChanged", None)
+        if signal is not None:
+            signal.connect(self._handle_visibility_changed)
+
+    def _handle_visibility_changed(self, *args) -> None:
+        stop_timer_if_view_hidden(self._view, self._timer)
 
     def _focus_root(self) -> None:
         try:


### PR DESCRIPTION
## Summary

This fixes two PyQt viewer issues:

- closed viewers can now be reopened with `show ...`
- `namedWindow()` / `imshow()` now create and show windows correctly on the first trigger

## Details

- unified viewer relaunch logic so hidden/closed viewers are restarted instead of being treated as already open
- updated `imshow` window handling so a hidden or closed window is shown again when needed
- added safe teardown handling to avoid crashes while exiting
